### PR TITLE
#24: Move CI test to AWS Codebuild

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .idea
 .pytest_cache
 dist
+__pycache__/

--- a/aws-code-build/ci/buildspec.yaml
+++ b/aws-code-build/ci/buildspec.yaml
@@ -1,0 +1,25 @@
+version: 0.2
+
+env:
+  shell: bash
+  variables:
+    RUN_DEVELOPER_SANDBOX_CI_TEST: "true"
+
+phases:
+
+  install:
+    runtime-versions:
+      python: 3.8
+    commands:
+      - git submodule update --init --recursive
+      - curl -sSL https://raw.githubusercontent.com/python-poetry/poetry/master/get-poetry.py | python3 -
+      - export PATH=$PATH:$HOME/.poetry/bin
+      - poetry env use $(command -v "python3.8")
+      - poetry install
+
+  pre_build:
+      commands:
+        - echo RUN_DEVELOPER_SANDBOX_CI_TEST is "$RUN_DEVELOPER_SANDBOX_CI_TEST" #supposed to be true
+  build:
+      commands:
+        - poetry run python3 -m pytest -s test/test_ci*.py

--- a/doc/changes/changes_0.1.0.md
+++ b/doc/changes/changes_0.1.0.md
@@ -16,6 +16,7 @@ n/a
  - #3: Installed SLC dependencies via Ansible
  - #4: Implemented deployment and access of S3 Bucket for VM's
  - #5: Implemented export of VM's
+ - #24: Move CI test to AWS Codebuild
 
 ## Documentation
 

--- a/exasol_script_languages_developer_sandbox/cli/commands/__init__.py
+++ b/exasol_script_languages_developer_sandbox/cli/commands/__init__.py
@@ -6,3 +6,4 @@ from .reset_password import reset_password
 from .export_vm import export_vm
 from .create_vm import create_vm
 from .show_aws_assets import show_aws_assets
+from .setup_ci_codebuild import setup_ci_codebuild

--- a/exasol_script_languages_developer_sandbox/cli/commands/setup_ci_codebuild.py
+++ b/exasol_script_languages_developer_sandbox/cli/commands/setup_ci_codebuild.py
@@ -1,0 +1,19 @@
+from exasol_script_languages_developer_sandbox.cli.cli import cli
+from exasol_script_languages_developer_sandbox.cli.common import add_options
+from exasol_script_languages_developer_sandbox.cli.options.aws_options import aws_options
+from exasol_script_languages_developer_sandbox.cli.options.logging import logging_options, set_log_level
+from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
+from exasol_script_languages_developer_sandbox.lib.ci_codebuild.ci_codebuild import run_setup_ci_codebuild
+
+
+@cli.command()
+@add_options(aws_options)
+@add_options(logging_options)
+def setup_ci_codebuild(
+            aws_profile: str,
+            log_level: str):
+    """
+    Command to deploy the CI CodeBuild stack
+    """
+    set_log_level(log_level)
+    run_setup_ci_codebuild(AwsAccess(aws_profile))

--- a/exasol_script_languages_developer_sandbox/lib/asset_id.py
+++ b/exasol_script_languages_developer_sandbox/lib/asset_id.py
@@ -18,7 +18,7 @@ class AssetId:
 
     @property
     def stack_prefix(self):
-        return f"{self.stack_prefix}-{self._asset_id}".replace("_", "-")
+        return f"{self._stack_prefix}-{self._asset_id}".replace("_", "-")
 
     def __repr__(self):
         return self._asset_id

--- a/exasol_script_languages_developer_sandbox/lib/asset_id.py
+++ b/exasol_script_languages_developer_sandbox/lib/asset_id.py
@@ -1,6 +1,8 @@
 class AssetId:
-    def __init__(self, asset_id: str):
+    def __init__(self, asset_id: str, stack_prefix="EC2-SLC-DEV-SANDBOX-", ami_prefix="Exasol-SLC-Developer-Sandbox"):
         self._asset_id = asset_id
+        self._stack_prefix = stack_prefix
+        self._ami_prefix = ami_prefix
 
     @property
     def tag_value(self):
@@ -12,7 +14,11 @@ class AssetId:
 
     @property
     def ami_name(self):
-        return f"Exasol-SLC-Developer-Sandbox-{self._asset_id}"
+        return f"{self._ami_prefix}-{self._asset_id}"
+
+    @property
+    def stack_prefix(self):
+        return f"{self.stack_prefix}-{self._asset_id}".replace("_", "-")
 
     def __repr__(self):
         return self._asset_id

--- a/exasol_script_languages_developer_sandbox/lib/asset_id.py
+++ b/exasol_script_languages_developer_sandbox/lib/asset_id.py
@@ -18,7 +18,7 @@ class AssetId:
 
     @property
     def stack_prefix(self):
-        return f"{self._stack_prefix}-{self._asset_id}".replace("_", "-")
+        return f"{self._stack_prefix}-{self._asset_id}".replace("_", "-").replace(".", "_")
 
     def __repr__(self):
         return self._asset_id

--- a/exasol_script_languages_developer_sandbox/lib/asset_id.py
+++ b/exasol_script_languages_developer_sandbox/lib/asset_id.py
@@ -18,7 +18,7 @@ class AssetId:
 
     @property
     def stack_prefix(self):
-        return f"{self._stack_prefix}-{self._asset_id}".replace("_", "-").replace(".", "_")
+        return f"{self._stack_prefix}-{self._asset_id}".replace("_", "-").replace(".", "-")
 
     def __repr__(self):
         return self._asset_id

--- a/exasol_script_languages_developer_sandbox/lib/ci_codebuild/ci_codebuild.py
+++ b/exasol_script_languages_developer_sandbox/lib/ci_codebuild/ci_codebuild.py
@@ -1,14 +1,15 @@
-import logging
-
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
+from exasol_script_languages_developer_sandbox.lib.logging import get_status_logger, LogType
 from exasol_script_languages_developer_sandbox.lib.render_template import render_template
 from exasol_script_languages_developer_sandbox.lib.vm_bucket.vm_slc_bucket import find_vm_bucket
 
 STACK_NAME = "CI-TEST-CODEBUILD"
 
+LOG = get_status_logger(LogType.CI_CODEBUILD)
+
 
 def run_setup_ci_codebuild(aws_access: AwsAccess) -> None:
     yml = render_template("ci_code_build.jinja.yaml", vm_bucket=find_vm_bucket(aws_access))
     aws_access.upload_cloudformation_stack(yml, STACK_NAME)
-    logging.info(f"Deployed cloudformation stack {STACK_NAME}")
+    LOG.info(f"Deployed cloudformation stack {STACK_NAME}")
 

--- a/exasol_script_languages_developer_sandbox/lib/ci_codebuild/ci_codebuild.py
+++ b/exasol_script_languages_developer_sandbox/lib/ci_codebuild/ci_codebuild.py
@@ -1,0 +1,13 @@
+import logging
+
+from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
+from exasol_script_languages_developer_sandbox.lib.render_template import render_template
+
+STACK_NAME = "CI-TEST-CODEBUILD"
+
+
+def run_setup_ci_codebuild(aws_access: AwsAccess) -> None:
+    yml = render_template("ci_code_build.jinja.yaml")
+    aws_access.upload_cloudformation_stack(yml, STACK_NAME)
+    logging.info(f"Deployed cloudformation stack {STACK_NAME}")
+

--- a/exasol_script_languages_developer_sandbox/lib/ci_codebuild/ci_codebuild.py
+++ b/exasol_script_languages_developer_sandbox/lib/ci_codebuild/ci_codebuild.py
@@ -2,12 +2,13 @@ import logging
 
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
 from exasol_script_languages_developer_sandbox.lib.render_template import render_template
+from exasol_script_languages_developer_sandbox.lib.vm_bucket.vm_slc_bucket import find_vm_bucket
 
 STACK_NAME = "CI-TEST-CODEBUILD"
 
 
 def run_setup_ci_codebuild(aws_access: AwsAccess) -> None:
-    yml = render_template("ci_code_build.jinja.yaml")
+    yml = render_template("ci_code_build.jinja.yaml", vm_bucket=find_vm_bucket(aws_access))
     aws_access.upload_cloudformation_stack(yml, STACK_NAME)
     logging.info(f"Deployed cloudformation stack {STACK_NAME}")
 

--- a/exasol_script_languages_developer_sandbox/lib/run_create_vm.py
+++ b/exasol_script_languages_developer_sandbox/lib/run_create_vm.py
@@ -41,8 +41,8 @@ def run_create_vm(aws_access: AwsAccess, ec2_key_file: Optional[str], ec2_key_na
     source_ami = find_source_ami(aws_access, configuration.source_ami_filters)
     LOG.info(f"Using source ami: '{source_ami.name}' from {source_ami.creation_date}")
 
-    execution_generator = run_lifecycle_for_ec2(aws_access, ec2_key_file, ec2_key_name, None,
-                                                asset_id.tag_value, source_ami.id)
+    execution_generator = run_lifecycle_for_ec2(aws_access, ec2_key_file, ec2_key_name,
+                                                asset_id, source_ami.id)
 
     with EC2StackLifecycleContextManager(execution_generator, configuration) as ec2_data:
         ec2_instance_description, key_file_location = ec2_data

--- a/exasol_script_languages_developer_sandbox/lib/setup_ec2/cf_stack.py
+++ b/exasol_script_languages_developer_sandbox/lib/setup_ec2/cf_stack.py
@@ -1,5 +1,6 @@
 from typing import Optional
 
+from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
 from exasol_script_languages_developer_sandbox.lib.logging import get_status_logger, LogType
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.random_string_generator import get_random_str_of_length_n
@@ -30,14 +31,13 @@ class CloudformationStack:
     and when exiting the stack will be destroyed.
     """
 
-    def __init__(self, aws_access: AwsAccess, ec2_key_name: str, user_name: str, stack_prefix: Optional[str],
-                 tag_value: str, ami_id: str):
+    def __init__(self, aws_access: AwsAccess, ec2_key_name: str, user_name: str, asset_id: AssetId, ami_id: str):
         self._aws_access = aws_access
         self._stack_name = None
         self._ec2_key_name = ec2_key_name
         self._user_name = user_name
-        self._stack_prefix = stack_prefix or "EC2-SLC-DEV-SANDBOX-"
-        self._tag_value = tag_value
+        self._stack_prefix = asset_id.stack_prefix
+        self._tag_value = asset_id.tag_value
         self._ami_id = ami_id
 
     def _generate_stack_name(self) -> str:

--- a/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2.py
+++ b/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2.py
@@ -58,8 +58,8 @@ def run_setup_ec2(aws_access: AwsAccess, ec2_key_file: Optional[str], ec2_key_na
     source_ami = find_source_ami(aws_access, configuration.source_ami_filters)
     LOG.info(f"Using source ami: '{source_ami.name}' from {source_ami.creation_date}")
     execution_generator = run_lifecycle_for_ec2(aws_access, ec2_key_file, ec2_key_name,
-                                                asset_id, config.global_config.source_ami_id)
-    with EC2StackLifecycleContextManager(execution_generator) as res:
+                                                asset_id, source_ami.id)
+    with EC2StackLifecycleContextManager(execution_generator, configuration) as res:
         ec2_instance_description, key_file_location = res
 
         if not ec2_instance_description.is_running:

--- a/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2.py
+++ b/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2.py
@@ -19,11 +19,10 @@ LOG = get_status_logger(LogType.SETUP)
 
 def run_lifecycle_for_ec2(aws_access: AwsAccess,
                           ec2_key_file: Optional[str], ec2_key_name: Optional[str],
-                          stack_prefix: Optional[str], tag_value: str, ami_id: str) -> Generator:
-    with KeyFileManagerContextManager(KeyFileManager(aws_access, ec2_key_name, ec2_key_file, tag_value)) as km:
+                          asset_id: AssetId, ami_id: str) -> Generator:
+    with KeyFileManagerContextManager(KeyFileManager(aws_access, ec2_key_name, ec2_key_file, asset_id.tag_value)) as km:
         with CloudformationStackContextManager(CloudformationStack(aws_access, km.key_name,
-                                                                   aws_access.get_user(), stack_prefix,
-                                                                   tag_value, ami_id)) \
+                                                                   aws_access.get_user(), asset_id, ami_id)) \
                 as cf_stack:
             ec2_instance_id = cf_stack.get_ec2_instance_id()
 
@@ -58,9 +57,9 @@ def run_setup_ec2(aws_access: AwsAccess, ec2_key_file: Optional[str], ec2_key_na
                   asset_id: AssetId, configuration: ConfigObject) -> None:
     source_ami = find_source_ami(aws_access, configuration.source_ami_filters)
     LOG.info(f"Using source ami: '{source_ami.name}' from {source_ami.creation_date}")
-    execution_generator = run_lifecycle_for_ec2(aws_access, ec2_key_file, ec2_key_name, None,
-                                                asset_id.tag_value, source_ami.id)
-    with EC2StackLifecycleContextManager(execution_generator, configuration) as res:
+    execution_generator = run_lifecycle_for_ec2(aws_access, ec2_key_file, ec2_key_name,
+                                                asset_id, config.global_config.source_ami_id)
+    with EC2StackLifecycleContextManager(execution_generator) as res:
         ec2_instance_description, key_file_location = res
 
         if not ec2_instance_description.is_running:

--- a/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2_and_install_dependencies.py
+++ b/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2_and_install_dependencies.py
@@ -1,4 +1,3 @@
-import logging
 import signal
 import time
 from typing import Tuple, Optional

--- a/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2_and_install_dependencies.py
+++ b/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2_and_install_dependencies.py
@@ -38,8 +38,8 @@ def run_setup_ec2_and_install_dependencies(aws_access: AwsAccess,
     """
     source_ami = find_source_ami(aws_access, configuration.source_ami_filters)
     LOG.info(f"Using source ami: '{source_ami.name}' from {source_ami.creation_date}")
-    execution_generator = run_lifecycle_for_ec2(aws_access, ec2_key_file, ec2_key_name, None,
-                                                asset_id.tag_value, source_ami.id)
+    execution_generator = run_lifecycle_for_ec2(aws_access, ec2_key_file, ec2_key_name,
+                                                asset_id, source_ami.id)
     with EC2StackLifecycleContextManager(execution_generator, configuration) as res:
         ec2_instance_description, key_file_location = res
 

--- a/exasol_script_languages_developer_sandbox/runtime/ansible/roles/poetry/tasks/main.yml
+++ b/exasol_script_languages_developer_sandbox/runtime/ansible/roles/poetry/tasks/main.yml
@@ -4,6 +4,7 @@
   apt:
     name: "{{apt_dependencies}}"
     state: present
+    update_cache: yes
   become: "{{need_sudo}}"
 - name: Install Poetry
   shell: "curl -sSL https://install.python-poetry.org | python3 - -y"

--- a/exasol_script_languages_developer_sandbox/runtime/ansible/roles/script_languages/tasks/main.yml
+++ b/exasol_script_languages_developer_sandbox/runtime/ansible/roles/script_languages/tasks/main.yml
@@ -4,8 +4,8 @@
   apt:
     name: "{{apt_dependencies}}"
     state: present
+    update_cache: yes
   become: "{{need_sudo}}"
-
 - name: Git checkout script-languages-release
   ansible.builtin.git:
     repo: 'https://github.com/exasol/script-languages-release.git'

--- a/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
+++ b/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
@@ -19,7 +19,6 @@ Resources:
             Version: '2012-10-17'
             Statement:
               - Action:
-                - codebuild:*
                 - logs:*
                 Resource: "*"
                 Effect: Allow

--- a/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
+++ b/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
@@ -1,24 +1,4 @@
 Resources:
-  ArtifactsBucket:
-    Type: AWS::S3::Bucket
-    Properties:
-      PublicAccessBlockConfiguration:
-        BlockPublicAcls: true
-        BlockPublicPolicy: true
-        IgnorePublicAcls: true
-        RestrictPublicBuckets: true
-      BucketEncryption:
-        ServerSideEncryptionConfiguration:
-          - ServerSideEncryptionByDefault:
-              SSEAlgorithm: 'aws:kms'
-              KMSMasterKeyID: !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/aws/s3"
-            BucketKeyEnabled: true
-      LifecycleConfiguration:
-        Rules:
-          - Id: ExpirationRule
-            Status: Enabled
-            ExpirationInDays: 30
-
   CodeBuildRole:
     Type: AWS::IAM::Role
     Properties:
@@ -45,15 +25,13 @@ Resources:
                 Resource: '*'
               - Effect: Allow
                 Action:
-                  - s3:PutObject
-                  - s3:GetObject
-                Resource:
-                  - !Sub "arn:aws:s3:::${ArtifactsBucket}/*"
-              - Effect: Allow
-                Action:
                   - ec2:*
                   - cloudformation:*
                 Resource: '*'
+              - Effect: Allow
+                Action:
+                  - s3:*
+                Resource: arn:aws:s3:::{{vm_bucket}}/*
   DeveloperSandboxCICodeBuild:
     Type: AWS::CodeBuild::Project
     Properties:
@@ -70,9 +48,7 @@ Resources:
                Pattern: \[CodeBuild\]
       ServiceRole: !GetAtt CodeBuildRole.Arn
       Artifacts:
-        Location: !Ref ArtifactsBucket
-        OverrideArtifactName: true
-        Type: S3
+        Type: NO_ARTIFACTS
       Environment:
         Type: LINUX_CONTAINER
         ComputeType: BUILD_GENERAL1_SMALL

--- a/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
+++ b/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
@@ -58,7 +58,7 @@ Resources:
                 Action:
                   - iam:GetUser
                 Resource:
-                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/${AWS::StackName}-CodeBuildRole-*"
+                  - '*'
   DeveloperSandboxCICodeBuild:
     Type: AWS::CodeBuild::Project
     Properties:

--- a/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
+++ b/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
@@ -54,11 +54,6 @@ Resources:
                   - ec2:*
                   - cloudformation:*
                 Resource: '*'
-              - Effect: Allow
-                Action:
-                  - iam:GetUser
-                Resource:
-                  - '*'
   DeveloperSandboxCICodeBuild:
     Type: AWS::CodeBuild::Project
     Properties:

--- a/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
+++ b/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
@@ -32,13 +32,13 @@ Resources:
                 - cloudformation:DescribeChangeSet
                 - cloudformation:ExecuteChangeSet
                 - cloudformation:DeleteStack
-                Resource: arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/stack-ci-test-*
+                Resource: !Sub  "arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/stack-ci-test-*"
                 Effect: Allow
               - Action:
                 - ec2:CreateSecurityGroup
                 - ec2:DeleteSecurityGroup
                 - ec2:AuthorizeSecurityGroupIngress
-                Resource: arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:security-group/*
+                Resource: !Sub "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:security-group/*"
                 Effect: Allow
               - Action:
                 - ec2:RunInstances
@@ -59,7 +59,7 @@ Resources:
               - Action:
                 - ec2:CreateKeyPair
                 - ec2:DeleteKeyPair
-                Resource: arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:key-pair/ec2-key-*
+                Resource: !Sub  "arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:key-pair/ec2-key-*"
                 Effect: Allow
               - Action:
                 - s3:GetBucketLocation

--- a/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
+++ b/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
@@ -18,46 +18,55 @@ Resources:
           PolicyDocument:
             Version: '2012-10-17'
             Statement:
-              - Effect: Allow
-                Action:
-                  - codebuild:*
-                  - logs:*
-                Resource: '*'
-              - Effect: Allow
-                Action:
-                  - ec2:CreateSecurityGroup
-                  - ec2:DeleteSecurityGroup
-                  - ec2:AuthorizeSecurityGroupIngress
-                  - ec2:CreateTags
-
-                Resource: "arn:aws:ec2:eu-central-1:620087982706:security-group/*",
-            - Effect: Allow
-              Action:
-                  - ec2:RunInstances
-                  - ec2:TerminateInstances
-                  - ec2:DescribeInstances
-                  - ec2:CreateTags
-                  - ec2:DescribeImages
-                  - ec2:DescribeSnapshots
-                  - ec2:DescribeSecurityGroups
-                  - ec2:DescribeExportImageTasks
-                  - ec2:DescribeKeyPairs
-                  - ec2:DescribeInstanceStatus
-                  - ec2:CreateImage
-                  - ec2:DeregisterImage
-                  - ec2:DeleteSnapshot
-              Resource: "*"
-            - Effect: Allow
-              Action:
-                  - ec2:CreateKeyPair
-                  - ec2:DeleteKeyPair
-              Resource: arn:aws:ec2:eu-central-1:620087982706:key-pair/ec2-key-*
-            - Effect: Allow
-              Action:
-                  - s3:GetBucketLocation
-                  - s3:ListBucket
-              Resource: arn:aws:s3:::vm-slc-bucket-vmslcbucket-jf66gs2p8rvh
-
+              - Action:
+                - codebuild:*
+                - logs:*
+                Resource: "*"
+                Effect: Allow
+              - Action:
+                - cloudformation:DescribeStacks
+                - cloudformation:ListStackResources
+                Resource: "*"
+                Effect: Allow
+              - Action:
+                - cloudformation:CreateChangeSet
+                - cloudformation:DescribeChangeSet
+                - cloudformation:ExecuteChangeSet
+                - cloudformation:DeleteStack
+                Resource: arn:aws:cloudformation:${AWS::Region}:${AWS::AccountId}:stack/stack-ci-test-*
+                Effect: Allow
+              - Action:
+                - ec2:CreateSecurityGroup
+                - ec2:DeleteSecurityGroup
+                - ec2:AuthorizeSecurityGroupIngress
+                Resource: arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:security-group/*
+                Effect: Allow
+              - Action:
+                - ec2:RunInstances
+                - ec2:TerminateInstances
+                - ec2:DescribeInstances
+                - ec2:CreateTags
+                - ec2:DescribeImages
+                - ec2:DescribeSnapshots
+                - ec2:DescribeSecurityGroups
+                - ec2:DescribeExportImageTasks
+                - ec2:DescribeKeyPairs
+                - ec2:DescribeInstanceStatus
+                - ec2:CreateImage
+                - ec2:DeregisterImage
+                - ec2:DeleteSnapshot
+                Resource: "*"
+                Effect: Allow
+              - Action:
+                - ec2:CreateKeyPair
+                - ec2:DeleteKeyPair
+                Resource: arn:aws:ec2:${AWS::Region}:${AWS::AccountId}:key-pair/ec2-key-*
+                Effect: Allow
+              - Action:
+                - s3:GetBucketLocation
+                - s3:ListBucket
+                Resource: arn:aws:s3:::{{vm_bucket}}
+                Effect: Allow
   DeveloperSandboxCICodeBuild:
     Type: AWS::CodeBuild::Project
     Properties:

--- a/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
+++ b/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
@@ -54,6 +54,11 @@ Resources:
                   - ec2:*
                   - cloudformation:*
                 Resource: '*'
+              - Effect: Allow
+                Action:
+                  - iam:GetUser
+                Resource:
+                  - !Sub "arn:aws:iam::${AWS::AccountId}:role/${AWS::StackName}-CodeBuildRole-*"
   DeveloperSandboxCICodeBuild:
     Type: AWS::CodeBuild::Project
     Properties:

--- a/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
+++ b/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
@@ -1,0 +1,96 @@
+Resources:
+  ArtifactsBucket:
+    Type: AWS::S3::Bucket
+    Properties:
+      PublicAccessBlockConfiguration:
+        BlockPublicAcls: true
+        BlockPublicPolicy: true
+        IgnorePublicAcls: true
+        RestrictPublicBuckets: true
+      BucketEncryption:
+        ServerSideEncryptionConfiguration:
+          - ServerSideEncryptionByDefault:
+              SSEAlgorithm: 'aws:kms'
+              KMSMasterKeyID: !Sub "arn:aws:kms:${AWS::Region}:${AWS::AccountId}:alias/aws/s3"
+            BucketKeyEnabled: true
+      LifecycleConfiguration:
+        Rules:
+          - Id: ExpirationRule
+            Status: Enabled
+            ExpirationInDays: 30
+
+  CodeBuildRole:
+    Type: AWS::IAM::Role
+    Properties:
+      AssumeRolePolicyDocument:
+        Version: 2012-10-17
+        Statement:
+            - Effect: Allow
+              Principal:
+                  Service:
+                    - codebuild.amazonaws.com
+              Action:
+                - sts:AssumeRole
+      Description: !Sub "IAM Role for ${AWS::StackName}"
+      Path: '/'
+      Policies:
+        - PolicyName: root
+          PolicyDocument:
+            Version: '2012-10-17'
+            Statement:
+              - Effect: Allow
+                Action:
+                  - codebuild:*
+                  - logs:*
+                Resource: '*'
+              - Effect: Allow
+                Action:
+                  - s3:PutObject
+                  - s3:GetObject
+                Resource:
+                  - !Sub "arn:aws:s3:::${ArtifactsBucket}/*"
+              - Effect: Allow
+                Action:
+                  - ec2:*
+                  - cloudformation:*
+                Resource: '*'
+  DeveloperSandboxCICodeBuild:
+    Type: AWS::CodeBuild::Project
+    Properties:
+      Description: CI Build which runs CI test if script-languages-developer-sandbox
+      Triggers:
+        Webhook: True
+        FilterGroups:
+          -  - Type: EVENT
+               Pattern: PUSH
+             - Type: HEAD_REF
+               Pattern: ^refs/heads/main$
+               ExcludeMatchedPattern: true
+             - Type: COMMIT_MESSAGE
+               Pattern: \[CodeBuild\]
+      ServiceRole: !GetAtt CodeBuildRole.Arn
+      Artifacts:
+        Location: !Ref ArtifactsBucket
+        OverrideArtifactName: true
+        Type: S3
+      Environment:
+        Type: LINUX_CONTAINER
+        ComputeType: BUILD_GENERAL1_SMALL
+        Image: aws/codebuild/standard:5.0
+      Source:
+        Type: GITHUB
+        Location: "https://github.com/exasol/script-languages-developer-sandbox"
+        BuildSpec: "aws-code-build/ci/buildspec.yaml"
+      TimeoutInMinutes: 240
+
+#Trick to have log retention, see https://medium.com/allermedia-techblog/cloudformation-example-log-retention-for-lambda-and-codebuild-a11e74516bb6
+  CodeBuildLogGroup:
+    Type: AWS::Logs::LogGroup
+    Properties:
+      LogGroupName: !Sub "/aws/codebuild/${ DeveloperSandboxCICodeBuild }"
+      RetentionInDays: 14
+
+Outputs:
+  ProjectName:
+    Value: !Ref DeveloperSandboxCICodeBuild
+    Description: Developer Sandbox CI Build project name

--- a/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
+++ b/exasol_script_languages_developer_sandbox/templates/ci_code_build.jinja.yaml
@@ -25,13 +25,39 @@ Resources:
                 Resource: '*'
               - Effect: Allow
                 Action:
-                  - ec2:*
-                  - cloudformation:*
-                Resource: '*'
-              - Effect: Allow
-                Action:
-                  - s3:*
-                Resource: arn:aws:s3:::{{vm_bucket}}/*
+                  - ec2:CreateSecurityGroup
+                  - ec2:DeleteSecurityGroup
+                  - ec2:AuthorizeSecurityGroupIngress
+                  - ec2:CreateTags
+
+                Resource: "arn:aws:ec2:eu-central-1:620087982706:security-group/*",
+            - Effect: Allow
+              Action:
+                  - ec2:RunInstances
+                  - ec2:TerminateInstances
+                  - ec2:DescribeInstances
+                  - ec2:CreateTags
+                  - ec2:DescribeImages
+                  - ec2:DescribeSnapshots
+                  - ec2:DescribeSecurityGroups
+                  - ec2:DescribeExportImageTasks
+                  - ec2:DescribeKeyPairs
+                  - ec2:DescribeInstanceStatus
+                  - ec2:CreateImage
+                  - ec2:DeregisterImage
+                  - ec2:DeleteSnapshot
+              Resource: "*"
+            - Effect: Allow
+              Action:
+                  - ec2:CreateKeyPair
+                  - ec2:DeleteKeyPair
+              Resource: arn:aws:ec2:eu-central-1:620087982706:key-pair/ec2-key-*
+            - Effect: Allow
+              Action:
+                  - s3:GetBucketLocation
+                  - s3:ListBucket
+              Resource: arn:aws:s3:::vm-slc-bucket-vmslcbucket-jf66gs2p8rvh
+
   DeveloperSandboxCICodeBuild:
     Type: AWS::CodeBuild::Project
     Properties:

--- a/poetry.lock
+++ b/poetry.lock
@@ -48,13 +48,13 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-tests = ["PyYAML (>=3.10)", "prance[osv] (>=0.11)", "marshmallow (>=3.13.0)", "pytest", "mock"]
-marshmallow = ["marshmallow (>=3.13.0)"]
+dev = ["PyYAML (>=3.10)", "prance[osv] (>=0.11)", "marshmallow (>=3.13.0)", "pytest", "mock", "flake8 (==4.0.1)", "flake8-bugbear (==22.4.25)", "pre-commit (>=2.4,<3.0)", "mypy (==0.950)", "types-pyyaml", "tox"]
 docs = ["marshmallow (>=3.13.0)", "pyyaml (==6.0)", "sphinx (==4.5.0)", "sphinx-issues (==3.0.1)", "sphinx-rtd-theme (==1.0.0)"]
 lint = ["flake8 (==4.0.1)", "flake8-bugbear (==22.4.25)", "pre-commit (>=2.4,<3.0)", "mypy (==0.950)", "types-pyyaml"]
-dev = ["PyYAML (>=3.10)", "prance[osv] (>=0.11)", "marshmallow (>=3.13.0)", "pytest", "mock", "flake8 (==4.0.1)", "flake8-bugbear (==22.4.25)", "pre-commit (>=2.4,<3.0)", "mypy (==0.950)", "types-pyyaml", "tox"]
-yaml = ["PyYAML (>=3.10)"]
+marshmallow = ["marshmallow (>=3.13.0)"]
+tests = ["PyYAML (>=3.10)", "prance[osv] (>=0.11)", "marshmallow (>=3.13.0)", "pytest", "mock"]
 validation = ["prance[osv] (>=0.11)"]
+yaml = ["PyYAML (>=3.10)"]
 
 [[package]]
 name = "atomicwrites"
@@ -73,10 +73,10 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 
 [[package]]
 name = "aws-sam-translator"
@@ -105,19 +105,19 @@ python-versions = ">=3.6"
 cffi = ">=1.1"
 
 [package.extras]
-typecheck = ["mypy"]
 tests = ["pytest (>=3.2.1,!=3.3.0)"]
+typecheck = ["mypy"]
 
 [[package]]
 name = "boto3"
-version = "1.24.56"
+version = "1.24.57"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 
 [package.dependencies]
-botocore = ">=1.27.56,<1.28.0"
+botocore = ">=1.27.57,<1.28.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -126,7 +126,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.27.56"
+version = "1.27.57"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -235,11 +235,11 @@ python-versions = ">=3.6"
 cffi = ">=1.12"
 
 [package.extras]
-pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
+docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
 docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
+pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
 sdist = ["setuptools_rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
-docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
 test = ["pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
@@ -298,12 +298,12 @@ optional = false
 python-versions = ">=3.6,<4.0"
 
 [package.extras]
-doh = ["h2 (>=4.1.0)", "httpx (>=0.21.1)", "requests (>=2.23.0,<3.0.0)", "requests-toolbelt (>=0.9.1,<0.10.0)"]
 dnssec = ["cryptography (>=2.6,<37.0)"]
+curio = ["curio (>=1.2,<2.0)", "sniffio (>=1.1,<2.0)"]
+doh = ["h2 (>=4.1.0)", "httpx (>=0.21.1)", "requests (>=2.23.0,<3.0.0)", "requests-toolbelt (>=0.9.1,<0.10.0)"]
+idna = ["idna (>=2.1,<4.0)"]
 trio = ["trio (>=0.14,<0.20)"]
 wmi = ["wmi (>=1.5.1,<2.0.0)"]
-curio = ["curio (>=1.2,<2.0)", "sniffio (>=1.1,<2.0)"]
-idna = ["idna (>=2.1,<4.0)"]
 
 [[package]]
 name = "docker"
@@ -318,8 +318,8 @@ requests = ">=2.14.2,<2.18.0 || >2.18.0"
 websocket-client = ">=0.32.0"
 
 [package.extras]
-tls = ["pyOpenSSL (>=17.5.0)", "cryptography (>=3.4.7)", "idna (>=2.0.0)"]
 ssh = ["paramiko (>=2.4.2)"]
+tls = ["pyOpenSSL (>=17.5.0)", "cryptography (>=3.4.7)", "idna (>=2.0.0)"]
 
 [[package]]
 name = "docutils"
@@ -341,8 +341,8 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 six = ">=1.9.0"
 
 [package.extras]
-gmpy2 = ["gmpy2"]
 gmpy = ["gmpy"]
+gmpy2 = ["gmpy2"]
 
 [[package]]
 name = "exasol-error-reporting-python"
@@ -532,8 +532,8 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 perf = ["ipython"]
+testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
 
 [[package]]
 name = "importlib-resources"
@@ -622,8 +622,8 @@ python-versions = ">=2.7"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-"testing.libs" = ["simplejson", "ujson", "yajl"]
 testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-black-multipy", "pytest-cov", "ecdsa", "feedparser", "numpy", "pandas", "pymongo", "scikit-learn", "sqlalchemy", "pytest-flake8 (<1.1.0)", "enum34", "jsonlib", "pytest-flake8 (>=1.1.1)"]
+"testing.libs" = ["simplejson", "ujson", "yajl"]
 
 [[package]]
 name = "jsonpointer"
@@ -647,8 +647,8 @@ pyrsistent = ">=0.14.0"
 six = ">=1.11.0"
 
 [package.extras]
-format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator (>0.1.0)", "rfc3339-validator"]
 format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
+format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator (>0.1.0)", "rfc3339-validator"]
 
 [[package]]
 name = "junit-xml"
@@ -687,10 +687,10 @@ stevedore = ">=3.4.0"
 tailer = ">=0.4.1"
 
 [package.extras]
-test = ["coverage[toml] (>=5.5)", "deepdiff (>=5.5.0)", "jsonpath-ng (>=1.5.3)", "pytest (==6.2.4)", "pytest-httpserver (>=1.0.1)", "pytest-rerunfailures (==10.0)"]
-full = ["airspeed (==0.5.19)", "amazon-kclpy-ext (==1.5.1)", "aws-sam-translator (>=1.15.1)", "awscli (>=1.22.90)", "boto (>=2.49.0)", "botocore (>=1.12.13)", "cbor2 (>=5.2.0)", "crontab (>=0.22.6)", "cryptography", "docker (==5.0.0)", "flask (>=1.0.2)", "flask-cors (>=3.0.3,<3.1.0)", "flask-swagger (==0.2.12)", "jsonpatch (>=1.24,<2.0)", "jsonpath-rw (>=1.4.0,<2.0.0)", "localstack-ext[runtime] (==0.14.5)", "moto-ext[all] (==3.1.12)", "opensearch-py (==1.1.0)", "pproxy (>=2.7.0)", "pyopenssl (>=21.0.0)", "Quart (>=0.6.15)", "readerwriterlock (>=1.0.7)", "requests-aws4auth (==0.9)", "Werkzeug (>=2.0)", "xmltodict (>=0.11.0)"]
 dev = ["black (==22.3.0)", "coveralls (==3.1.0)", "cython", "flake8 (>=3.6.0)", "flake8-black (==0.3.2)", "flake8-isort (>=4.0.0)", "flake8-quotes (>=0.11.0)", "pre-commit (==2.13.0)", "pyproject-flake8", "isort (==5.9.1)", "pandoc", "pypandoc", "autoflake"]
+full = ["airspeed (==0.5.19)", "amazon-kclpy-ext (==1.5.1)", "aws-sam-translator (>=1.15.1)", "awscli (>=1.22.90)", "boto (>=2.49.0)", "botocore (>=1.12.13)", "cbor2 (>=5.2.0)", "crontab (>=0.22.6)", "cryptography", "docker (==5.0.0)", "flask (>=1.0.2)", "flask-cors (>=3.0.3,<3.1.0)", "flask-swagger (==0.2.12)", "jsonpatch (>=1.24,<2.0)", "jsonpath-rw (>=1.4.0,<2.0.0)", "localstack-ext[runtime] (==0.14.5)", "moto-ext[all] (==3.1.12)", "opensearch-py (==1.1.0)", "pproxy (>=2.7.0)", "pyopenssl (>=21.0.0)", "Quart (>=0.6.15)", "readerwriterlock (>=1.0.7)", "requests-aws4auth (==0.9)", "Werkzeug (>=2.0)", "xmltodict (>=0.11.0)"]
 runtime = ["airspeed (==0.5.19)", "amazon-kclpy-ext (==1.5.1)", "aws-sam-translator (>=1.15.1)", "awscli (>=1.22.90)", "boto (>=2.49.0)", "botocore (>=1.12.13)", "cbor2 (>=5.2.0)", "crontab (>=0.22.6)", "cryptography", "docker (==5.0.0)", "flask (>=1.0.2)", "flask-cors (>=3.0.3,<3.1.0)", "flask-swagger (==0.2.12)", "jsonpatch (>=1.24,<2.0)", "jsonpath-rw (>=1.4.0,<2.0.0)", "localstack-ext[runtime] (==0.14.5)", "moto-ext[all] (==3.1.12)", "opensearch-py (==1.1.0)", "pproxy (>=2.7.0)", "pyopenssl (>=21.0.0)", "Quart (>=0.6.15)", "readerwriterlock (>=1.0.7)", "requests-aws4auth (==0.9)", "Werkzeug (>=2.0)", "xmltodict (>=0.11.0)"]
+test = ["coverage[toml] (>=5.5)", "deepdiff (>=5.5.0)", "jsonpath-ng (>=1.5.3)", "pytest (==6.2.4)", "pytest-httpserver (>=1.0.1)", "pytest-rerunfailures (==10.0)"]
 
 [[package]]
 name = "localstack-client"
@@ -727,11 +727,11 @@ requests = ">=2.20.0,<2.26"
 tabulate = "*"
 
 [package.extras]
+package = ["python-minifier"]
+runtime = ["avro (>=1.11.0)", "amazon.ion (==0.8)", "aws-encryption-sdk (>=3.1.0)", "dirtyjson (==1.0.7)", "docker-registry-client (>=0.5.2)", "docker (==5.0.0)", "dulwich (>=0.19.16)", "flask (>=1.0.2)", "graphql-core (>=3.0.3)", "janus (>=0.5.0)", "jsonpatch (>=1.32)", "Js2Py (>=0.71)", "kafka-python", "kubernetes (==21.7.0)", "localstack[runtime] (>=0.14.3.4)", "moto-ext[all] (>=3.1.12)", "paho-mqtt (>=1.5)", "parse (==1.19.0)", "parquet (>=1.3.1)", "pg8000 (>=1.10)", "postgres (>=2.2.2)", "postgresql-proxy (>=0.0.1)", "presto-python-client (>=0.7.0)", "pyftpdlib (>=1.5.6)", "pyhive[hive] (>=0.6.1)", "pyion2json (>=0.0.2)", "PyJWT (>=1.7.0)", "pyqldb (>=3.2,<4.0)", "python-snappy (>=0.6)", "readerwriterlock (>=1.0.7)", "rsa (>=4.0)", "sql-metadata (>=2.6.0)", "srp-ext (==1.0.7.1)", "testing.common.database (>=1.1.0)", "tornado (>=6.0)", "warrant-ext (>=0.6.2)", "websockets (>=8.1)", "Whoosh (>=2.7.4)"]
 test = ["aiohttp", "appdirs", "aws_xray_sdk (>=2.4.2)", "azure-common (>=1.1.26)", "azure-core (>=1.9.0)", "azure-devops (>=6.0.0b4)", "azure-functions (>=1.5.0)", "azure-identity (>=1.5.0)", "azure-mgmt-core (>=1.2.2)", "azure-mgmt-storage (>=16.0.0)", "azure-mgmt-web (>=1.0.0)", "azure-servicebus (>=7.0.1)", "azure-storage-blob (>=12.3.0)", "azure-storage-queue (>=12.1.1)", "black (==22.3.0)", "coverage[toml] (>=5.0.0)", "coveralls", "flake8-black (==0.3.2)", "flake8-isort (>=4.0.0)", "flake8-quotes (>=0.11.0)", "flake8 (==3.9.2)", "gremlinpython (==3.5.1)", "isort (==5.9.1)", "Js2Py (>=0.71)", "jws (>=0.1.3)", "localstack[test] (>=0.14.3.2)", "msal", "msal-extensions", "msrest", "nest-asyncio (>=1.4.1)", "paramiko (>=2.11.0,<2.12.0)", "portalocker", "pre-commit (==2.13.0)", "pyarrow", "pykafka", "pymongo", "pymssql", "pymysql", "pyproject-flake8", "pytest-dependency (==0.5.1)", "pytest-httpserver (>=1.0.1)", "pytest-instafail (>=0.4.2)", "pytest-rerunfailures (==10.0)", "pytest (==6.2.4)", "redis (==3.3.7)", "redshift-connector"]
 test_ext = ["pyathena"]
-runtime = ["avro (>=1.11.0)", "amazon.ion (==0.8)", "aws-encryption-sdk (>=3.1.0)", "dirtyjson (==1.0.7)", "docker-registry-client (>=0.5.2)", "docker (==5.0.0)", "dulwich (>=0.19.16)", "flask (>=1.0.2)", "graphql-core (>=3.0.3)", "janus (>=0.5.0)", "jsonpatch (>=1.32)", "Js2Py (>=0.71)", "kafka-python", "kubernetes (==21.7.0)", "localstack[runtime] (>=0.14.3.4)", "moto-ext[all] (>=3.1.12)", "paho-mqtt (>=1.5)", "parse (==1.19.0)", "parquet (>=1.3.1)", "pg8000 (>=1.10)", "postgres (>=2.2.2)", "postgresql-proxy (>=0.0.1)", "presto-python-client (>=0.7.0)", "pyftpdlib (>=1.5.6)", "pyhive[hive] (>=0.6.1)", "pyion2json (>=0.0.2)", "PyJWT (>=1.7.0)", "pyqldb (>=3.2,<4.0)", "python-snappy (>=0.6)", "readerwriterlock (>=1.0.7)", "rsa (>=4.0)", "sql-metadata (>=2.6.0)", "srp-ext (==1.0.7.1)", "testing.common.database (>=1.1.0)", "tornado (>=6.0)", "warrant-ext (>=0.6.2)", "websockets (>=8.1)", "Whoosh (>=2.7.4)"]
 test_overrides = ["moto-ext[all] (>=3.1.10)"]
-package = ["python-minifier"]
 
 [[package]]
 name = "lockfile"
@@ -785,10 +785,10 @@ python-versions = ">=3.8"
 
 [package.extras]
 default = ["numpy (>=1.19)", "scipy (>=1.8)", "matplotlib (>=3.4)", "pandas (>=1.3)"]
-doc = ["sphinx (>=5)", "pydata-sphinx-theme (>=0.9)", "sphinx-gallery (>=0.10)", "numpydoc (>=1.4)", "pillow (>=9.1)", "nb2plots (>=0.6)", "texext (>=0.6.6)"]
-test = ["pytest (>=7.1)", "pytest-cov (>=3.0)", "codecov (>=2.1)"]
 developer = ["pre-commit (>=2.20)", "mypy (>=0.961)"]
+doc = ["sphinx (>=5)", "pydata-sphinx-theme (>=0.9)", "sphinx-gallery (>=0.10)", "numpydoc (>=1.4)", "pillow (>=9.1)", "nb2plots (>=0.6)", "texext (>=0.6.6)"]
 extra = ["lxml (>=4.6)", "pygraphviz (>=1.9)", "pydot (>=1.4.2)", "sympy (>=1.10)"]
+test = ["pytest (>=7.1)", "pytest-cov (>=3.0)", "codecov (>=2.1)"]
 
 [[package]]
 name = "numpy"
@@ -856,8 +856,8 @@ pynacl = ">=1.0.1"
 six = "*"
 
 [package.extras]
-ed25519 = ["pynacl (>=1.0.1)", "bcrypt (>=3.1.3)"]
 all = ["pyasn1 (>=0.1.7)", "pynacl (>=1.0.1)", "bcrypt (>=3.1.3)", "invoke (>=1.3)", "gssapi (>=1.4.1)", "pywin32 (>=2.1.8)"]
+ed25519 = ["pynacl (>=1.0.1)", "bcrypt (>=3.1.3)"]
 gssapi = ["pyasn1 (>=0.1.7)", "gssapi (>=1.4.1)", "pywin32 (>=2.1.8)"]
 invoke = ["invoke (>=1.3)"]
 
@@ -900,8 +900,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-testing = ["pytest", "pytest-benchmark"]
 dev = ["pre-commit", "tox"]
+testing = ["pytest", "pytest-benchmark"]
 
 [[package]]
 name = "plux"
@@ -1016,10 +1016,10 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
-tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
 crypto = ["cryptography (>=3.3.1)"]
 dev = ["sphinx", "sphinx-rtd-theme", "zope.interface", "cryptography (>=3.3.1)", "pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)", "mypy", "pre-commit"]
+docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
+tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
 
 [[package]]
 name = "pynacl"
@@ -1197,10 +1197,10 @@ optional = false
 python-versions = "*"
 
 [package.extras]
+examples = ["html5lib", "packaging", "pygraphviz", "requests"]
+lint = ["black", "flake8", "mypy", "isort", "types-requests"]
 release = ["build", "towncrier", "twine"]
 test = ["commentjson", "packaging", "pytest"]
-lint = ["black", "flake8", "mypy", "isort", "types-requests"]
-examples = ["html5lib", "packaging", "pygraphviz", "requests"]
 
 [[package]]
 name = "rich"
@@ -1390,9 +1390,9 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-test = ["websockets"]
 docs = ["Sphinx (>=3.4)", "sphinx-rtd-theme (>=0.5)"]
 optional = ["python-socks", "wsaccel"]
+test = ["websockets"]
 
 [[package]]
 name = "wrapt"
@@ -1462,12 +1462,12 @@ bcrypt = [
     {file = "bcrypt-3.2.2.tar.gz", hash = "sha256:433c410c2177057705da2a9f2cd01dd157493b2a7ac14c8593a16b3dab6b6bfb"},
 ]
 boto3 = [
-    {file = "boto3-1.24.56-py3-none-any.whl", hash = "sha256:09fb94008bd1f2566ef79ec7d8dd7a233b5da67f3b2536e30432eb8e88022d4d"},
-    {file = "boto3-1.24.56.tar.gz", hash = "sha256:9fab8acec76008797be4671d514f39f1163ba044c0a0bce8d5afe8b52cbd5550"},
+    {file = "boto3-1.24.57-py3-none-any.whl", hash = "sha256:74a50c718594a38fa846ce6951ea4704a5836194e2d4055e959baef39299d283"},
+    {file = "boto3-1.24.57.tar.gz", hash = "sha256:1be1aa320ef33d6e10e82adea3caeb0d2c185284457d1e2406339b44f45d7565"},
 ]
 botocore = [
-    {file = "botocore-1.27.56-py3-none-any.whl", hash = "sha256:81df81b1a1c5608b3a7aca6a837acb27552c3ecc92584a58b171c60754b1d4eb"},
-    {file = "botocore-1.27.56.tar.gz", hash = "sha256:81101abab2013992a84019739d85a6fa8ec6f1f42fb09ad07e0bf4c8f0efce60"},
+    {file = "botocore-1.27.57-py3-none-any.whl", hash = "sha256:e55510321dba95065a071909177ab6d4e1621b41f090cefe54252af9b0766855"},
+    {file = "botocore-1.27.57.tar.gz", hash = "sha256:f3dd75a789ac1a3e3f06fe0725ee138522c106c4e6abc917a4915617c4a32662"},
 ]
 cachetools = [
     {file = "cachetools-3.1.1-py2.py3-none-any.whl", hash = "sha256:428266a1c0d36dc5aca63a2d7c5942e88c2c898d72139fca0e97fdd2380517ae"},

--- a/setup.py
+++ b/setup.py
@@ -10,6 +10,7 @@ packages = \
  'exasol_script_languages_developer_sandbox.lib.ansible',
  'exasol_script_languages_developer_sandbox.lib.asset_printing',
  'exasol_script_languages_developer_sandbox.lib.aws_access',
+ 'exasol_script_languages_developer_sandbox.lib.ci_codebuild',
  'exasol_script_languages_developer_sandbox.lib.export_vm',
  'exasol_script_languages_developer_sandbox.lib.setup_ec2',
  'exasol_script_languages_developer_sandbox.lib.vm_bucket',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -13,7 +13,7 @@ from exasol_script_languages_developer_sandbox.lib.vm_bucket.vm_slc_bucket impor
 
 from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 
-DEFAULT_ASSET_ID = AssetId("test")
+DEFAULT_ASSET_ID = AssetId("test", stack_prefix="test-stack", ami_prefix="test-ami")
 
 TEST_DUMMY_AMI_ID = "ami-123"
 
@@ -34,6 +34,11 @@ def ec2_cloudformation_yml():
 @pytest.fixture
 def vm_bucket_cloudformation_yml():
     return render_template("vm_bucket_cloudformation.jinja.yaml", bucket_name=BUCKET_NAME, role_name=ROLE_NAME)
+
+
+@pytest.fixture
+def codebuild_cloudformation_yml():
+    return render_template("ci_code_build.jinja.yaml", vm_bucket="test-bucket-123")
 
 
 @pytest.fixture(scope="session")

--- a/test/localstack_test.py
+++ b/test/localstack_test.py
@@ -13,8 +13,8 @@ def test_ec2_lifecycle_with_local_stack(local_stack, default_asset_id, test_dumm
     This test uses localstack to simulate lifecycle of an EC-2 instance
     """
     print("run ec2_setup!")
-    execution_generator = run_lifecycle_for_ec2(AwsLocalStackAccess(None), None, None, None,
-                                                default_asset_id.tag_value, test_dummy_ami_id)
+    execution_generator = run_lifecycle_for_ec2(AwsLocalStackAccess(None), None, None,
+                                                default_asset_id, test_dummy_ami_id)
     ec2_data = next(execution_generator)
     ec2_instance_description, key_file_location = ec2_data
     while ec2_instance_description.is_pending:
@@ -104,7 +104,7 @@ Resources:
 def test_cloudformation_access_with_local_stack(local_stack, default_asset_id, test_dummy_ami_id):
     aws_access = AwsLocalStackAccess(None)
     with CloudformationStackContextManager(CloudformationStack(aws_access, "test_key", aws_access.get_user(),
-                                                               None, default_asset_id.tag_value,
+                                                               default_asset_id,
                                                                test_dummy_ami_id)) \
             as cf_stack:
         ec2_instance_id = cf_stack.get_ec2_instance_id()

--- a/test/test_ci.py
+++ b/test/test_ci.py
@@ -29,7 +29,7 @@ from exasol_script_languages_developer_sandbox.lib.tags import DEFAULT_TAG_KEY
 
 class AwsCiAccess(AwsAccess):
     """
-    We can't use Aws.getUser() without parameters when executing from within a IAM Role, and not a User account.
+    We can't use AwsAccess.getUser() without parameters when executing from within an IAM Role, and not a User account.
     (Boto3 throws an exception).
     Hence, we overwrite the default implementation and return a standard value.
     """
@@ -74,7 +74,9 @@ def new_ec2_from_ami():
     assert default_password != new_password
     aws_access = AwsCiAccess(aws_profile=None)
     asset_id = AssetId("ci-test-{suffix}-{now}".format(now=datetime.now().strftime("%Y-%m-%d-%H-%M-%S"),
-                                                       suffix=DEFAULT_ID))
+                                                       suffix=DEFAULT_ID),
+                       stack_prefix="stack",
+                       ami_prefix="ami")
     run_create_vm(aws_access, None, None,
                   AnsibleAccess(), default_password, tuple(), asset_id, default_config_object)
 
@@ -83,9 +85,7 @@ def new_ec2_from_ami():
     assert len(amis) == 1
     ami = amis[0]
 
-    stack_prefix = str(asset_id).replace(".", "-")
-    lifecycle_generator = run_lifecycle_for_ec2(aws_access, None, None, stack_prefix=stack_prefix,
-                                                tag_value=asset_id.tag_value, ami_id=ami.id)
+    lifecycle_generator = run_lifecycle_for_ec2(aws_access, None, None, asset_id=asset_id, ami_id=ami.id)
 
     try:
         with EC2StackLifecycleContextManager(lifecycle_generator, default_config_object) as ec2_data:

--- a/test/test_deploy_codebuild.py
+++ b/test/test_deploy_codebuild.py
@@ -1,0 +1,11 @@
+from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
+from test.cloudformation_validation import validate_using_cfn_lint
+
+
+def test_deploy_ec2_template(codebuild_cloudformation_yml):
+    aws_access = AwsAccess(None)
+    aws_access.validate_cloudformation_template(codebuild_cloudformation_yml)
+
+
+def test_deploy_cec2_template_with_cnf_lint(tmp_path, codebuild_cloudformation_yml):
+    validate_using_cfn_lint(tmp_path, codebuild_cloudformation_yml)

--- a/test/test_deploy_ec2.py
+++ b/test/test_deploy_ec2.py
@@ -33,7 +33,7 @@ def test_deploy_ec2_custom_prefix(ec2_cloudformation_yml, default_asset_id, test
     with CloudformationStackContextManager(CloudformationStack(aws_access_mock,
                                                                "test_key", "test_user", default_asset_id,
                                                                test_dummy_ami_id)) as cf_access:
-        assert cf_access.stack_name.startswith("test_prefix")
+        assert cf_access.stack_name.startswith("test-stack")
 
 
 def test_deploy_ec2_template(ec2_cloudformation_yml):

--- a/test/test_deploy_ec2.py
+++ b/test/test_deploy_ec2.py
@@ -14,7 +14,7 @@ def test_deploy_ec2_upload_invoked(ec2_cloudformation_yml, default_asset_id, tes
     """
     aws_access_mock = MagicMock()
     with CloudformationStackContextManager(CloudformationStack(aws_access_mock, "test_key", "test_user",
-                                                               None, default_asset_id.tag_value,
+                                                               default_asset_id,
                                                                test_dummy_ami_id)) \
             as cf_access:
         pass
@@ -31,8 +31,7 @@ def test_deploy_ec2_custom_prefix(ec2_cloudformation_yml, default_asset_id, test
     aws_access_mock = MagicMock()
     aws_access_mock.stack_exists.return_value = False
     with CloudformationStackContextManager(CloudformationStack(aws_access_mock,
-                                                               "test_key", "test_user", "test_prefix",
-                                                               default_asset_id.tag_value,
+                                                               "test_key", "test_user", default_asset_id,
                                                                test_dummy_ami_id)) as cf_access:
         assert cf_access.stack_name.startswith("test_prefix")
 

--- a/test/test_run_lifecycle_for_ec2.py
+++ b/test/test_run_lifecycle_for_ec2.py
@@ -32,8 +32,8 @@ def test_run_lifecycle_for_ec2(default_asset_id, test_dummy_ami_id):
             EC2Instance({"InstanceId": "abc", "State": {"Name": "running"}, "PublicDnsName": "public_host"})
         ]
     aws_access_mock.describe_instance.side_effect = instances_states
-    res_gen = run_lifecycle_for_ec2(aws_access_mock, "test_key_file_loc", "test_key", None,
-                                    default_asset_id.tag_value, test_dummy_ami_id)
+    res_gen = run_lifecycle_for_ec2(aws_access_mock, "test_key_file_loc", "test_key",
+                                    default_asset_id, test_dummy_ami_id)
     res = next(res_gen)
     ec2_instance_description, key_file_loc = res
 
@@ -90,8 +90,8 @@ def test_run_lifecycle_for_ec2_with_context_manager(default_asset_id, test_dummy
             EC2Instance({"InstanceId": "abc", "State": {"Name": "running"}, "PublicDnsName": "public_host"})
         ]
     aws_access_mock.describe_instance.side_effect = instances_states
-    res_gen = run_lifecycle_for_ec2(aws_access_mock, "test_key_file_loc", "test_key", None,
-                                    default_asset_id.tag_value, test_dummy_ami_id)
+    res_gen = run_lifecycle_for_ec2(aws_access_mock, "test_key_file_loc", "test_key",
+                                    default_asset_id, test_dummy_ami_id)
     with EC2StackLifecycleContextManager(res_gen, test_config) as res:
         ec2_instance_description, key_file_location = res
         assert not aws_access_mock.create_new_ec2_key_pair.called

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -58,7 +58,7 @@ def create_cloudformation_stack_and_serialize(tmp_location_key_manager: Path, tm
         with open(tmp_location_key_manager, "wb") as f:
             pickle.dump(key_file_manager, f)
         cloudformation = CloudformationStack(aws_access, key_file_manager.key_name,
-                                             aws_access.get_user(), None, default_asset_id.tag_value,
+                                             aws_access.get_user(), default_asset_id,
                                              test_dummy_ami_id)
         cloudformation.upload_cloudformation_stack()
         with open(tmp_location_cloudformation, "wb") as f:


### PR DESCRIPTION
fixes #24 

1. Created a new cloudformation template to deploy an AWS Codebuild project to execute the ci-test:
 - the codebuild is only triggered if the commit message contains the string "[CodeBuild]". This is to reduce cost and not run the build for every push
2. Created a new click command which can be used to deploy the AWS Codebuild project
3. Refactored handling of the stack prefix for the cloudformation stacks: It's now included in class `AssetId`