### PR TITLE
#26: Implemented search for latest AMI

### DIFF
--- a/doc/changes/changes_0.1.0.md
+++ b/doc/changes/changes_0.1.0.md
@@ -24,3 +24,4 @@ n/a
 ## Refactoring
 
  - #22: Improved logging
+ - #26: Implemented search for latest AMI

--- a/exasol_script_languages_developer_sandbox/cli/commands/create_vm.py
+++ b/exasol_script_languages_developer_sandbox/cli/commands/create_vm.py
@@ -13,6 +13,7 @@ from exasol_script_languages_developer_sandbox.lib.ansible.ansible_access import
 from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
 from exasol_script_languages_developer_sandbox.lib.logging import set_log_level
+from exasol_script_languages_developer_sandbox.lib.config import default_config_object
 from exasol_script_languages_developer_sandbox.lib.run_create_vm import run_create_vm
 
 
@@ -39,4 +40,5 @@ def create_vm(
     current_vm_image_formats = tuple() if no_vm else vm_image_format
     set_log_level(log_level)
     run_create_vm(AwsAccess(aws_profile), ec2_key_file, ec2_key_name,
-                  AnsibleAccess(), default_password, current_vm_image_formats, AssetId(asset_id))
+                  AnsibleAccess(), default_password, current_vm_image_formats,
+                  AssetId(asset_id), default_config_object)

--- a/exasol_script_languages_developer_sandbox/cli/commands/export_vm.py
+++ b/exasol_script_languages_developer_sandbox/cli/commands/export_vm.py
@@ -10,6 +10,7 @@ from exasol_script_languages_developer_sandbox.cli.options.logging import loggin
 from exasol_script_languages_developer_sandbox.cli.options.vm_options import vm_options
 from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
+from exasol_script_languages_developer_sandbox.lib.config import default_config_object
 from exasol_script_languages_developer_sandbox.lib.export_vm.run_export_vm import run_export_vm
 from exasol_script_languages_developer_sandbox.lib.logging import set_log_level
 
@@ -34,4 +35,5 @@ def export_vm(
     """
     current_vm_image_formats = tuple() if no_vm else vm_image_format
     set_log_level(log_level)
-    run_export_vm(AwsAccess(aws_profile), stack_name, current_vm_image_formats, AssetId(asset_id))
+    run_export_vm(AwsAccess(aws_profile), stack_name, current_vm_image_formats,
+                  AssetId(asset_id), default_config_object)

--- a/exasol_script_languages_developer_sandbox/cli/commands/setup_ec2.py
+++ b/exasol_script_languages_developer_sandbox/cli/commands/setup_ec2.py
@@ -27,4 +27,4 @@ def setup_ec2(
     Debug command to test setup of an EC-2 instance.
     """
     set_log_level(log_level)
-    run_setup_ec2(AwsAccess(aws_profile), ec2_key_file, ec2_key_name, AssetId(asset_id))
+    run_setup_ec2(AwsAccess(aws_profile), ec2_key_file, ec2_key_name, AssetId(asset_id), default_config_object)

--- a/exasol_script_languages_developer_sandbox/cli/commands/setup_ec2_and_install_dependencies.py
+++ b/exasol_script_languages_developer_sandbox/cli/commands/setup_ec2_and_install_dependencies.py
@@ -10,6 +10,7 @@ from exasol_script_languages_developer_sandbox.lib.ansible.ansible_access import
 from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
 from exasol_script_languages_developer_sandbox.lib.logging import set_log_level
+from exasol_script_languages_developer_sandbox.lib.config import default_config_object
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.run_setup_ec2_and_install_dependencies import \
     run_setup_ec2_and_install_dependencies
 
@@ -30,4 +31,4 @@ def setup_ec2_and_install_dependencies(
     """
     set_log_level(log_level)
     run_setup_ec2_and_install_dependencies(AwsAccess(aws_profile), ec2_key_file, ec2_key_name,
-                                           AssetId(asset_id), AnsibleAccess())
+                                           AssetId(asset_id), AnsibleAccess(), default_config_object)

--- a/exasol_script_languages_developer_sandbox/lib/config.py
+++ b/exasol_script_languages_developer_sandbox/lib/config.py
@@ -1,7 +1,7 @@
 
 default_config = {
     "time_to_wait_for_polling": 10.0,
-    # Source AMI is set to Ubuntu 20.04
+    # Source AMI is set to Ubuntu 20.04. Owner id '099720109477' == 'Canonical'
     "source_ami_filters": {
         "name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*",
         "owner-id": "099720109477",
@@ -16,4 +16,4 @@ class ConfigObject:
         self.__dict__.update(kwargs)
 
 
-global_config = ConfigObject(**default_config)
+default_config_object = ConfigObject(**default_config)

--- a/exasol_script_languages_developer_sandbox/lib/config.py
+++ b/exasol_script_languages_developer_sandbox/lib/config.py
@@ -2,7 +2,12 @@
 default_config = {
     "time_to_wait_for_polling": 10.0,
     # Source AMI is set to Ubuntu 20.04
-    "source_ami_id": "ami-0c9354388bb36c088"
+    "source_ami_filters": {
+        "name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-*",
+        "owner-id": "099720109477",
+        "architecture": "x86_64",
+        "state": "available"
+    }
 }
 
 
@@ -12,4 +17,3 @@ class ConfigObject:
 
 
 global_config = ConfigObject(**default_config)
-

--- a/exasol_script_languages_developer_sandbox/lib/export_vm/run_export_vm.py
+++ b/exasol_script_languages_developer_sandbox/lib/export_vm/run_export_vm.py
@@ -2,7 +2,6 @@ import time
 from dataclasses import dataclass
 from typing import Tuple
 
-from exasol_script_languages_developer_sandbox.lib import config
 from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
 from exasol_script_languages_developer_sandbox.lib.aws_access.export_image_task import ExportImageTask
@@ -30,17 +29,19 @@ class ExportImageTaskProgress:
         return ExportImageTaskProgress(progress=export_image_task.progress, status=export_image_task.status)
 
 
-def poll_export_image_task(aws_access: AwsAccess, export_image_task: ExportImageTask) -> ExportImageTask:
+def poll_export_image_task(aws_access: AwsAccess, export_image_task: ExportImageTask,
+                           configuration: ConfigObject) -> ExportImageTask:
     """
     Checks a started exported-image-task in a loop until it completes or fails.
 
     :param aws_access: Aws Access proxy
     :param export_image_task:  the newly started export image task object.
+    :param configuration: The global configuration object.
     :return: The export-image-task object after the task has completed or failed.
     """
     last_progress = ExportImageTaskProgress.from_export_image_task(export_image_task)
     while export_image_task.is_active:
-        time.sleep(config.global_config.time_to_wait_for_polling)
+        time.sleep(configuration.time_to_wait_for_polling)
         export_image_task = aws_access.get_export_image_task(export_image_task.id)
         progress = ExportImageTaskProgress.from_export_image_task(export_image_task)
         if last_progress != progress:
@@ -52,7 +53,8 @@ def poll_export_image_task(aws_access: AwsAccess, export_image_task: ExportImage
 
 
 def export_vm_image(aws_access: AwsAccess, vm_image_format: VmDiskImageFormat, tag_value: str,
-                    ami_id: str, vmimport_role: str, vm_bucket: str, bucket_prefix: str):
+                    ami_id: str, vmimport_role: str, vm_bucket: str, bucket_prefix: str,
+                    configuration: ConfigObject):
     """
     Exports an AMI (parameter ami_id) to a VM image in the given S3-Bucket (parameter vm_bucket)
     at prefix (parameter bucket_prefix). The format of the VM is given by parameter vm_image_format.
@@ -69,12 +71,13 @@ def export_vm_image(aws_access: AwsAccess, vm_image_format: VmDiskImageFormat, t
     export_image_task = aws_access.get_export_image_task(export_image_task_id)
     LOG.info(f"Started export of vm image to {vm_bucket}/{bucket_prefix}. "
              f"Status message is {export_image_task.status_message}.")
-    export_image_task = poll_export_image_task(aws_access, export_image_task)
+    export_image_task = poll_export_image_task(aws_access, export_image_task, configuration)
     if not export_image_task.is_completed:
         raise RuntimeError(f"Export of VM failed: status message was {export_image_task.status_message}")
 
 
-def create_ami(aws_access: AwsAccess, ami_name: str, tag_value: str, instance_id: str, cfg: ConfigObject) -> str:
+def create_ami(aws_access: AwsAccess, ami_name: str, tag_value: str,
+               instance_id: str, configuration: ConfigObject) -> str:
     """
     Creates a new AMI with the given name (parameter ami_name) for the EC2-Instance identified by parameter instance_id.
     The AMI will be tagged with given tag_value.
@@ -88,7 +91,7 @@ def create_ami(aws_access: AwsAccess, ami_name: str, tag_value: str, instance_id
     ami = aws_access.get_ami(ami_id)
     while ami.is_pending:
         LOG.info(f"ami  with name '{ami.name}' and tag(s) '{tag_value}'  still pending...")
-        time.sleep(cfg.time_to_wait_for_polling)
+        time.sleep(configuration.time_to_wait_for_polling)
         ami = aws_access.get_ami(ami_id)
     if not ami.is_available:
         raise RuntimeError(f"Failed to create ami! ami state is '{ami.state}'")
@@ -99,7 +102,7 @@ def export_vm(aws_access: AwsAccess,
               instance_id: str,
               vm_image_formats: Tuple[str, ...],
               asset_id: AssetId,
-              cfg: ConfigObject) -> None:
+              configuration: ConfigObject) -> None:
     vm_bucket = find_vm_bucket(aws_access)
     vmimport_role = find_vm_import_role(aws_access)
     tag_value = asset_id.tag_value
@@ -107,7 +110,7 @@ def export_vm(aws_access: AwsAccess,
     has_errors = False
     try:
         try:
-            ami_id = create_ami(aws_access, asset_id.ami_name, tag_value, instance_id, cfg)
+            ami_id = create_ami(aws_access, asset_id.ami_name, tag_value, instance_id, configuration)
         except Exception:
             LOG.exception("Could not create AMI. Please remove snapshot if necessary!")
             has_errors = True
@@ -115,7 +118,7 @@ def export_vm(aws_access: AwsAccess,
         for vm_image_format in vm_image_formats:
             try:
                 export_vm_image(aws_access, VmDiskImageFormat[vm_image_format], tag_value,
-                                ami_id, vmimport_role, vm_bucket, bucket_prefix)
+                                ami_id, vmimport_role, vm_bucket, bucket_prefix, configuration)
             except Exception:
                 LOG.exception(f"Failed to export VM to bucket {vm_bucket} at {bucket_prefix}\n")
                 has_errors = True
@@ -133,9 +136,9 @@ def run_export_vm(aws_access: AwsAccess,
                   stack_name: str,
                   vm_image_formats: Tuple[str, ...],
                   asset_id: AssetId,
-                  cfg: ConfigObject):
+                  configuration: ConfigObject):
     """
     Runs export only of the VM image.
     """
     ec_instance_id = find_ec2_instance_in_cf_stack(aws_access, stack_name)
-    export_vm(aws_access, ec_instance_id, vm_image_formats, asset_id, cfg)
+    export_vm(aws_access, ec_instance_id, vm_image_formats, asset_id, configuration)

--- a/exasol_script_languages_developer_sandbox/lib/logging.py
+++ b/exasol_script_languages_developer_sandbox/lib/logging.py
@@ -13,6 +13,7 @@ class LogType(Enum):
     CI_CODEBUILD = "ci_codebuild"
     AWS_ACCESS = "aws_access"
     ANSIBLE = "ansible"
+    CREATE_VM = "create_vm"
 
 
 def get_status_logger(log_type: LogType) -> logging.Logger:

--- a/exasol_script_languages_developer_sandbox/lib/run_create_vm.py
+++ b/exasol_script_languages_developer_sandbox/lib/run_create_vm.py
@@ -1,4 +1,3 @@
-import logging
 import time
 from typing import Tuple, Optional, List
 
@@ -10,6 +9,7 @@ from exasol_script_languages_developer_sandbox.lib.ansible.ansible_run_context i
 from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
 from exasol_script_languages_developer_sandbox.lib.config import ConfigObject
+from exasol_script_languages_developer_sandbox.lib.logging import get_status_logger, LogType
 
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.host_info import HostInfo
 from exasol_script_languages_developer_sandbox.lib.export_vm.run_export_vm import export_vm
@@ -20,11 +20,14 @@ from exasol_script_languages_developer_sandbox.lib.setup_ec2.run_setup_ec2 impor
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.source_ami import find_source_ami
 
 
+LOG = get_status_logger(LogType.CREATE_VM)
+
+
 def run_create_vm(aws_access: AwsAccess, ec2_key_file: Optional[str], ec2_key_name: Optional[str],
                   ansible_access: AnsibleAccess, default_password: str,
                   vm_image_formats: Tuple[str, ...],
                   asset_id: AssetId,
-                  cfg: ConfigObject,
+                  configuration: ConfigObject,
                   ansible_run_context=default_ansible_run_context,
                   ansible_reset_password_context=reset_password_ansible_run_context,
                   ansible_repositories: Tuple[AnsibleRepository, ...] = default_repositories) \
@@ -35,20 +38,20 @@ def run_create_vm(aws_access: AwsAccess, ec2_key_file: Optional[str], ec2_key_na
     If anything goes wrong the cloudformation stack of the EC-2 instance will be removed.
     For debuging you can use the available debug commands.
     """
-    source_ami = find_source_ami(aws_access, cfg.source_ami_filters)
-    logging.info(f"Using source ami: '{source_ami.name}' from {source_ami.creation_date}")
+    source_ami = find_source_ami(aws_access, configuration.source_ami_filters)
+    LOG.info(f"Using source ami: '{source_ami.name}' from {source_ami.creation_date}")
 
     execution_generator = run_lifecycle_for_ec2(aws_access, ec2_key_file, ec2_key_name, None,
                                                 asset_id.tag_value, source_ami.id)
 
-    with EC2StackLifecycleContextManager(execution_generator, cfg) as ec2_data:
+    with EC2StackLifecycleContextManager(execution_generator, configuration) as ec2_data:
         ec2_instance_description, key_file_location = ec2_data
         if not ec2_instance_description.is_running:
             raise RuntimeError(f"Error during startup of EC2 instance '{ec2_instance_description.id}'. "
                                f"Status is {ec2_instance_description.state_name}")
 
         # Wait for the EC-2 instance to become ready.
-        time.sleep(cfg.time_to_wait_for_polling)
+        time.sleep(configuration.time_to_wait_for_polling)
 
         host_name = ec2_instance_description.public_dns_name
         run_install_dependencies(ansible_access, (HostInfo(host_name, key_file_location),),
@@ -56,4 +59,4 @@ def run_create_vm(aws_access: AwsAccess, ec2_key_file: Optional[str], ec2_key_na
         run_reset_password(ansible_access, default_password,
                            (HostInfo(host_name, key_file_location),), ansible_reset_password_context,
                            ansible_repositories)
-        return export_vm(aws_access, ec2_instance_description.id, vm_image_formats, asset_id, cfg)
+        return export_vm(aws_access, ec2_instance_description.id, vm_image_formats, asset_id, configuration)

--- a/exasol_script_languages_developer_sandbox/lib/run_create_vm.py
+++ b/exasol_script_languages_developer_sandbox/lib/run_create_vm.py
@@ -2,7 +2,6 @@ import logging
 import time
 from typing import Tuple, Optional, List
 
-from exasol_script_languages_developer_sandbox.lib import config
 from exasol_script_languages_developer_sandbox.lib.ansible.ansible_access import AnsibleAccess
 from exasol_script_languages_developer_sandbox.lib.ansible.ansible_repository import AnsibleRepository, \
     default_repositories
@@ -10,6 +9,7 @@ from exasol_script_languages_developer_sandbox.lib.ansible.ansible_run_context i
     reset_password_ansible_run_context, default_ansible_run_context
 from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
+from exasol_script_languages_developer_sandbox.lib.config import ConfigObject
 
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.host_info import HostInfo
 from exasol_script_languages_developer_sandbox.lib.export_vm.run_export_vm import export_vm
@@ -24,6 +24,7 @@ def run_create_vm(aws_access: AwsAccess, ec2_key_file: Optional[str], ec2_key_na
                   ansible_access: AnsibleAccess, default_password: str,
                   vm_image_formats: Tuple[str, ...],
                   asset_id: AssetId,
+                  cfg: ConfigObject,
                   ansible_run_context=default_ansible_run_context,
                   ansible_reset_password_context=reset_password_ansible_run_context,
                   ansible_repositories: Tuple[AnsibleRepository, ...] = default_repositories) \
@@ -34,20 +35,20 @@ def run_create_vm(aws_access: AwsAccess, ec2_key_file: Optional[str], ec2_key_na
     If anything goes wrong the cloudformation stack of the EC-2 instance will be removed.
     For debuging you can use the available debug commands.
     """
-    source_ami = find_source_ami(aws_access, config.global_config.source_ami_filters)
+    source_ami = find_source_ami(aws_access, cfg.source_ami_filters)
     logging.info(f"Using source ami: '{source_ami.name}' from {source_ami.creation_date}")
 
     execution_generator = run_lifecycle_for_ec2(aws_access, ec2_key_file, ec2_key_name, None,
                                                 asset_id.tag_value, source_ami.id)
 
-    with EC2StackLifecycleContextManager(execution_generator) as ec2_data:
+    with EC2StackLifecycleContextManager(execution_generator, cfg) as ec2_data:
         ec2_instance_description, key_file_location = ec2_data
         if not ec2_instance_description.is_running:
             raise RuntimeError(f"Error during startup of EC2 instance '{ec2_instance_description.id}'. "
                                f"Status is {ec2_instance_description.state_name}")
 
         # Wait for the EC-2 instance to become ready.
-        time.sleep(config.global_config.time_to_wait_for_polling)
+        time.sleep(cfg.time_to_wait_for_polling)
 
         host_name = ec2_instance_description.public_dns_name
         run_install_dependencies(ansible_access, (HostInfo(host_name, key_file_location),),
@@ -55,4 +56,4 @@ def run_create_vm(aws_access: AwsAccess, ec2_key_file: Optional[str], ec2_key_na
         run_reset_password(ansible_access, default_password,
                            (HostInfo(host_name, key_file_location),), ansible_reset_password_context,
                            ansible_repositories)
-        return export_vm(aws_access, ec2_instance_description.id, vm_image_formats, asset_id)
+        return export_vm(aws_access, ec2_instance_description.id, vm_image_formats, asset_id, cfg)

--- a/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2.py
+++ b/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2.py
@@ -2,7 +2,6 @@ import signal
 import time
 from typing import Optional, Tuple, Generator
 
-from exasol_script_languages_developer_sandbox.lib import config
 from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
 from exasol_script_languages_developer_sandbox.lib.aws_access.ec2_instance import EC2Instance
@@ -37,14 +36,15 @@ def run_lifecycle_for_ec2(aws_access: AwsAccess,
 
 
 class EC2StackLifecycleContextManager:
-    def __init__(self, lifecycle_generator: Generator):
+    def __init__(self, lifecycle_generator: Generator, cfg: ConfigObject):
         self._lifecycle_generator = lifecycle_generator
+        self._config = cfg
 
     def __enter__(self) -> Tuple[EC2Instance, str]:
         res = next(self._lifecycle_generator)
         while res[0].is_pending:
             LOG.info(f"EC2 instance not ready yet.")
-            time.sleep(config.global_config.time_to_wait_for_polling)
+            time.sleep(self._config.time_to_wait_for_polling)
             res = next(self._lifecycle_generator)
         ec2_instance_description, key_file_location = res
         return ec2_instance_description, key_file_location
@@ -54,12 +54,12 @@ class EC2StackLifecycleContextManager:
 
 
 def run_setup_ec2(aws_access: AwsAccess, ec2_key_file: Optional[str], ec2_key_name: Optional[str],
-                  asset_id: AssetId) -> None:
-    source_ami = find_source_ami(aws_access, config.global_config.source_ami_filters)
+                  asset_id: AssetId, cfg: ConfigObject) -> None:
+    source_ami = find_source_ami(aws_access, cfg.source_ami_filters)
     logging.info(f"Using source ami: '{source_ami.name}' from {source_ami.creation_date}")
     execution_generator = run_lifecycle_for_ec2(aws_access, ec2_key_file, ec2_key_name, None,
                                                 asset_id.tag_value, source_ami.id)
-    with EC2StackLifecycleContextManager(execution_generator) as res:
+    with EC2StackLifecycleContextManager(execution_generator, cfg) as res:
         ec2_instance_description, key_file_location = res
 
         if not ec2_instance_description.is_running:

--- a/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2.py
+++ b/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2.py
@@ -11,6 +11,7 @@ from exasol_script_languages_developer_sandbox.lib.setup_ec2.cf_stack import Clo
     CloudformationStackContextManager
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.key_file_manager import KeyFileManager, \
     KeyFileManagerContextManager
+from exasol_script_languages_developer_sandbox.lib.setup_ec2.source_ami import find_source_ami
 
 
 LOG = get_status_logger(LogType.SETUP)
@@ -54,8 +55,10 @@ class EC2StackLifecycleContextManager:
 
 def run_setup_ec2(aws_access: AwsAccess, ec2_key_file: Optional[str], ec2_key_name: Optional[str],
                   asset_id: AssetId) -> None:
+    source_ami = find_source_ami(aws_access, config.global_config.source_ami_filters)
+    logging.info(f"Using source ami: '{source_ami.name}' from {source_ami.creation_date}")
     execution_generator = run_lifecycle_for_ec2(aws_access, ec2_key_file, ec2_key_name, None,
-                                                asset_id.tag_value, config.global_config.source_ami_id)
+                                                asset_id.tag_value, source_ami.id)
     with EC2StackLifecycleContextManager(execution_generator) as res:
         ec2_instance_description, key_file_location = res
 

--- a/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2_and_install_dependencies.py
+++ b/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2_and_install_dependencies.py
@@ -17,6 +17,7 @@ from exasol_script_languages_developer_sandbox.lib.setup_ec2.host_info import Ho
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.run_install_dependencies import run_install_dependencies
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.run_setup_ec2 import run_lifecycle_for_ec2, \
     EC2StackLifecycleContextManager
+from exasol_script_languages_developer_sandbox.lib.setup_ec2.source_ami import find_source_ami
 
 
 LOG = get_status_logger(LogType.SETUP)
@@ -34,8 +35,10 @@ def run_setup_ec2_and_install_dependencies(aws_access: AwsAccess,
     gives you time to login into the machine and identify any setup issues.
     You can stop the EC-2 machine by pressing Ctrl-C.
     """
+    source_ami = find_source_ami(aws_access, config.global_config.source_ami_filters)
+    logging.info(f"Using source ami: '{source_ami.name}' from {source_ami.creation_date}")
     execution_generator = run_lifecycle_for_ec2(aws_access, ec2_key_file, ec2_key_name, None,
-                                                asset_id.tag_value, config.global_config.source_ami_id)
+                                                asset_id.tag_value, source_ami.id)
     with EC2StackLifecycleContextManager(execution_generator) as res:
         ec2_instance_description, key_file_location = res
 

--- a/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2_and_install_dependencies.py
+++ b/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2_and_install_dependencies.py
@@ -1,3 +1,4 @@
+import logging
 import signal
 import time
 from typing import Tuple, Optional
@@ -10,7 +11,6 @@ from exasol_script_languages_developer_sandbox.lib.ansible.ansible_run_context i
     default_ansible_run_context
 from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
-from exasol_script_languages_developer_sandbox.lib.logging import get_status_logger, LogType
 
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.host_info import HostInfo
 
@@ -35,11 +35,11 @@ def run_setup_ec2_and_install_dependencies(aws_access: AwsAccess,
     gives you time to login into the machine and identify any setup issues.
     You can stop the EC-2 machine by pressing Ctrl-C.
     """
-    source_ami = find_source_ami(aws_access, config.global_config.source_ami_filters)
+    source_ami = find_source_ami(aws_access, cfg.source_ami_filters)
     logging.info(f"Using source ami: '{source_ami.name}' from {source_ami.creation_date}")
     execution_generator = run_lifecycle_for_ec2(aws_access, ec2_key_file, ec2_key_name, None,
                                                 asset_id.tag_value, source_ami.id)
-    with EC2StackLifecycleContextManager(execution_generator) as res:
+    with EC2StackLifecycleContextManager(execution_generator, cfg) as res:
         ec2_instance_description, key_file_location = res
 
         if not ec2_instance_description.is_running:
@@ -49,7 +49,7 @@ def run_setup_ec2_and_install_dependencies(aws_access: AwsAccess,
             return
 
         #Wait for the EC-2 instance to become ready.
-        time.sleep(config.global_config.time_to_wait_for_polling)
+        time.sleep(cfg.time_to_wait_for_polling)
         host_name = ec2_instance_description.public_dns_name
         try:
             run_install_dependencies(ansible_access, (HostInfo(host_name, key_file_location),),

--- a/exasol_script_languages_developer_sandbox/lib/setup_ec2/source_ami.py
+++ b/exasol_script_languages_developer_sandbox/lib/setup_ec2/source_ami.py
@@ -1,0 +1,10 @@
+from typing import Dict
+
+from exasol_script_languages_developer_sandbox.lib.aws_access.ami import Ami
+from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
+
+
+def find_source_ami(aws_access: AwsAccess, filters: Dict[str, str]) -> Ami:
+    amis = aws_access.list_amis(filters=[{"Name": key, "Values": [value]} for key, value in filters.items()])
+    latest_ami = max(amis, key=lambda ami: ami.creation_date)
+    return latest_ami

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -4,8 +4,7 @@ import subprocess
 
 import pytest
 
-from exasol_script_languages_developer_sandbox.lib import config
-from exasol_script_languages_developer_sandbox.lib.config import ConfigObject
+from exasol_script_languages_developer_sandbox.lib.config import ConfigObject, default_config_object
 from exasol_script_languages_developer_sandbox.lib.render_template import render_template
 from importlib.metadata import version
 
@@ -63,12 +62,12 @@ def local_stack():
 
 
 @pytest.fixture(autouse=True)
-def override_config():
+def test_config():
     test_config = {
         "time_to_wait_for_polling": 0.01,
-        "source_ami_filters": config.global_config.source_ami_filters
+        "source_ami_filters": default_config_object.source_ami_filters
     }
-    config.global_config = ConfigObject(**test_config)
+    return ConfigObject(**test_config)
 
 
 @pytest.fixture()

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -69,3 +69,8 @@ def override_config():
         "source_ami_filters": config.global_config.source_ami_filters
     }
     config.global_config = ConfigObject(**test_config)
+
+
+@pytest.fixture()
+def test_dummy_ami_id():
+    return TEST_DUMMY_AMI_ID

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -16,6 +16,8 @@ from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 
 DEFAULT_ASSET_ID = AssetId("test")
 
+TEST_DUMMY_AMI_ID = "ami-123"
+
 
 @pytest.fixture
 def default_asset_id():
@@ -27,7 +29,7 @@ def ec2_cloudformation_yml():
 
     return render_template("ec2_cloudformation.jinja.yaml", key_name="test_key", user_name="test_user",
                            trace_tag=DEFAULT_TAG_KEY, trace_tag_value=DEFAULT_ASSET_ID.tag_value,
-                           ami_id=config.global_config.source_ami_id)
+                           ami_id=TEST_DUMMY_AMI_ID)
 
 
 @pytest.fixture
@@ -64,6 +66,6 @@ def local_stack():
 def override_config():
     test_config = {
         "time_to_wait_for_polling": 0.01,
-        "source_ami_id": config.global_config.source_ami_id
+        "source_ami_filters": config.global_config.source_ami_filters
     }
     config.global_config = ConfigObject(**test_config)

--- a/test/localstack_test.py
+++ b/test/localstack_test.py
@@ -1,7 +1,7 @@
 import botocore
 import pytest
 
-from exasol_script_languages_developer_sandbox.lib import config
+from conftest import TEST_DUMMY_AMI_ID
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.cf_stack import CloudformationStack, \
     CloudformationStackContextManager
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.run_setup_ec2 import run_lifecycle_for_ec2
@@ -15,7 +15,7 @@ def test_ec2_lifecycle_with_local_stack(local_stack, default_asset_id):
     """
     print("run ec2_setup!")
     execution_generator = run_lifecycle_for_ec2(AwsLocalStackAccess(None), None, None, None,
-                                                default_asset_id.tag_value, config.global_config.source_ami_id)
+                                                default_asset_id.tag_value, TEST_DUMMY_AMI_ID)
     ec2_data = next(execution_generator)
     ec2_instance_description, key_file_location = ec2_data
     while ec2_instance_description.is_pending:
@@ -106,7 +106,7 @@ def test_cloudformation_access_with_local_stack(local_stack, default_asset_id):
     aws_access = AwsLocalStackAccess(None)
     with CloudformationStackContextManager(CloudformationStack(aws_access, "test_key", aws_access.get_user(),
                                                                None, default_asset_id.tag_value,
-                                                               config.global_config.source_ami_id)) \
+                                                               TEST_DUMMY_AMI_ID)) \
             as cf_stack:
         ec2_instance_id = cf_stack.get_ec2_instance_id()
         ec2_instance_description = aws_access.describe_instance(ec2_instance_id)

--- a/test/localstack_test.py
+++ b/test/localstack_test.py
@@ -1,7 +1,6 @@
 import botocore
 import pytest
 
-from conftest import TEST_DUMMY_AMI_ID
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.cf_stack import CloudformationStack, \
     CloudformationStackContextManager
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.run_setup_ec2 import run_lifecycle_for_ec2
@@ -9,13 +8,13 @@ from exasol_script_languages_developer_sandbox.lib.tags import create_default_as
 from test.aws_local_stack_access import AwsLocalStackAccess
 
 
-def test_ec2_lifecycle_with_local_stack(local_stack, default_asset_id):
+def test_ec2_lifecycle_with_local_stack(local_stack, default_asset_id, test_dummy_ami_id):
     """
     This test uses localstack to simulate lifecycle of an EC-2 instance
     """
     print("run ec2_setup!")
     execution_generator = run_lifecycle_for_ec2(AwsLocalStackAccess(None), None, None, None,
-                                                default_asset_id.tag_value, TEST_DUMMY_AMI_ID)
+                                                default_asset_id.tag_value, test_dummy_ami_id)
     ec2_data = next(execution_generator)
     ec2_instance_description, key_file_location = ec2_data
     while ec2_instance_description.is_pending:
@@ -102,11 +101,11 @@ Resources:
         aws_access.validate_cloudformation_template(wrong_cloudformation_template)
 
 
-def test_cloudformation_access_with_local_stack(local_stack, default_asset_id):
+def test_cloudformation_access_with_local_stack(local_stack, default_asset_id, test_dummy_ami_id):
     aws_access = AwsLocalStackAccess(None)
     with CloudformationStackContextManager(CloudformationStack(aws_access, "test_key", aws_access.get_user(),
                                                                None, default_asset_id.tag_value,
-                                                               TEST_DUMMY_AMI_ID)) \
+                                                               test_dummy_ami_id)) \
             as cf_stack:
         ec2_instance_id = cf_stack.get_ec2_instance_id()
         ec2_instance_description = aws_access.describe_instance(ec2_instance_id)

--- a/test/test_ci.py
+++ b/test/test_ci.py
@@ -15,6 +15,7 @@ from exasol_script_languages_developer_sandbox.cli.options.id_options import DEF
 from exasol_script_languages_developer_sandbox.lib.ansible.ansible_access import AnsibleAccess
 from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
+from exasol_script_languages_developer_sandbox.lib.config import default_config_object
 from exasol_script_languages_developer_sandbox.lib.run_create_vm import run_create_vm
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.run_setup_ec2 import run_lifecycle_for_ec2, \
     EC2StackLifecycleContextManager
@@ -60,7 +61,7 @@ def new_ec2_from_ami():
     asset_id = AssetId("ci-test-{suffix}-{now}".format(now=datetime.now().strftime("%Y-%m-%d-%H-%M-%S"),
                                                        suffix=DEFAULT_ID))
     run_create_vm(aws_access, None, None,
-                  AnsibleAccess(), default_password, tuple(), asset_id)
+                  AnsibleAccess(), default_password, tuple(), asset_id, default_config_object)
 
     # Use the ami_name to find the AMI id (alternatively we could use the tag here)
     amis = aws_access.list_amis(filters=[{'Name': 'name', 'Values': [asset_id.ami_name]}])
@@ -72,7 +73,7 @@ def new_ec2_from_ami():
                                                 tag_value=asset_id.tag_value, ami_id=ami.id)
 
     try:
-        with EC2StackLifecycleContextManager(lifecycle_generator) as ec2_data:
+        with EC2StackLifecycleContextManager(lifecycle_generator, default_config_object) as ec2_data:
             ec2_instance_description, key_file_location = ec2_data
             assert ec2_instance_description.is_running
 

--- a/test/test_deploy_ec2.py
+++ b/test/test_deploy_ec2.py
@@ -1,6 +1,5 @@
 from unittest.mock import MagicMock
 
-from conftest import TEST_DUMMY_AMI_ID
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.cf_stack import CloudformationStack, \
     CloudformationStackContextManager
@@ -8,7 +7,7 @@ from exasol_script_languages_developer_sandbox.lib.tags import create_default_as
 from test.cloudformation_validation import validate_using_cfn_lint
 
 
-def test_deploy_ec2_upload_invoked(ec2_cloudformation_yml, default_asset_id):
+def test_deploy_ec2_upload_invoked(ec2_cloudformation_yml, default_asset_id, test_dummy_ami_id):
     """"
     Test if function upload_cloudformation_stack() will be invoked
     with expected values when we run run_deploy_ci_build()
@@ -16,7 +15,7 @@ def test_deploy_ec2_upload_invoked(ec2_cloudformation_yml, default_asset_id):
     aws_access_mock = MagicMock()
     with CloudformationStackContextManager(CloudformationStack(aws_access_mock, "test_key", "test_user",
                                                                None, default_asset_id.tag_value,
-                                                               TEST_DUMMY_AMI_ID)) \
+                                                               test_dummy_ami_id)) \
             as cf_access:
         pass
     default_tag = tuple(create_default_asset_tag(default_asset_id.tag_value))
@@ -25,7 +24,7 @@ def test_deploy_ec2_upload_invoked(ec2_cloudformation_yml, default_asset_id):
                                                                         tags=default_tag)
 
 
-def test_deploy_ec2_custom_prefix(ec2_cloudformation_yml, default_asset_id):
+def test_deploy_ec2_custom_prefix(ec2_cloudformation_yml, default_asset_id, test_dummy_ami_id):
     """"
     Test that the custom prefix will be used for the cloudformation stack name.
     """
@@ -34,7 +33,7 @@ def test_deploy_ec2_custom_prefix(ec2_cloudformation_yml, default_asset_id):
     with CloudformationStackContextManager(CloudformationStack(aws_access_mock,
                                                                "test_key", "test_user", "test_prefix",
                                                                default_asset_id.tag_value,
-                                                               TEST_DUMMY_AMI_ID)) as cf_access:
+                                                               test_dummy_ami_id)) as cf_access:
         assert cf_access.stack_name.startswith("test_prefix")
 
 

--- a/test/test_deploy_ec2.py
+++ b/test/test_deploy_ec2.py
@@ -1,6 +1,6 @@
 from unittest.mock import MagicMock
 
-from exasol_script_languages_developer_sandbox.lib import config
+from conftest import TEST_DUMMY_AMI_ID
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.cf_stack import CloudformationStack, \
     CloudformationStackContextManager
@@ -16,7 +16,7 @@ def test_deploy_ec2_upload_invoked(ec2_cloudformation_yml, default_asset_id):
     aws_access_mock = MagicMock()
     with CloudformationStackContextManager(CloudformationStack(aws_access_mock, "test_key", "test_user",
                                                                None, default_asset_id.tag_value,
-                                                               config.global_config.source_ami_id)) \
+                                                               TEST_DUMMY_AMI_ID)) \
             as cf_access:
         pass
     default_tag = tuple(create_default_asset_tag(default_asset_id.tag_value))
@@ -34,7 +34,7 @@ def test_deploy_ec2_custom_prefix(ec2_cloudformation_yml, default_asset_id):
     with CloudformationStackContextManager(CloudformationStack(aws_access_mock,
                                                                "test_key", "test_user", "test_prefix",
                                                                default_asset_id.tag_value,
-                                                               config.global_config.source_ami_id)) as cf_access:
+                                                               TEST_DUMMY_AMI_ID)) as cf_access:
         assert cf_access.stack_name.startswith("test_prefix")
 
 

--- a/test/test_export_vm.py
+++ b/test/test_export_vm.py
@@ -67,14 +67,14 @@ vm_formats = [
 
 
 @pytest.mark.parametrize("vm_formats_to_test", vm_formats)
-def test_export_vm(aws_vm_export_mock, default_asset_id, vm_formats_to_test):
+def test_export_vm(aws_vm_export_mock, default_asset_id, vm_formats_to_test, test_config):
     """"
     Test if function export_vm() will be invoked
     with expected values when we run_export_vm()
     """
     export_vm(aws_access=aws_vm_export_mock, instance_id=INSTANCE_ID,
               vm_image_formats=tuple(vm_image_format.value for vm_image_format in vm_formats_to_test),
-              asset_id=default_asset_id)
+              asset_id=default_asset_id, cfg=test_config)
 
     aws_vm_export_mock.create_image_from_ec2_instance.assert_called_once_with(INSTANCE_ID,
                                                                               name=default_asset_id.ami_name,

--- a/test/test_export_vm.py
+++ b/test/test_export_vm.py
@@ -74,7 +74,7 @@ def test_export_vm(aws_vm_export_mock, default_asset_id, vm_formats_to_test, tes
     """
     export_vm(aws_access=aws_vm_export_mock, instance_id=INSTANCE_ID,
               vm_image_formats=tuple(vm_image_format.value for vm_image_format in vm_formats_to_test),
-              asset_id=default_asset_id, cfg=test_config)
+              asset_id=default_asset_id, configuration=test_config)
 
     aws_vm_export_mock.create_image_from_ec2_instance.assert_called_once_with(INSTANCE_ID,
                                                                               name=default_asset_id.ami_name,

--- a/test/test_key_file_manager.py
+++ b/test/test_key_file_manager.py
@@ -41,4 +41,3 @@ def test_generated_key(default_asset_id):
     # Now call close. After that we expect that the key has been removed from AWS and the temporary file was removed.
     aws_access_mock.delete_ec2_key_pair.assert_called_once_with(key_name=key_name)
     assert not os.path.exists(km.key_file_location)
-

--- a/test/test_run_lifecycle_for_ec2.py
+++ b/test/test_run_lifecycle_for_ec2.py
@@ -2,7 +2,7 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from exasol_script_languages_developer_sandbox.lib import config
+from conftest import TEST_DUMMY_AMI_ID
 from exasol_script_languages_developer_sandbox.lib.aws_access.ec2_instance import EC2Instance
 from exasol_script_languages_developer_sandbox.lib.aws_access.stack_resource import StackResource
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.run_setup_ec2 import run_lifecycle_for_ec2, \
@@ -34,7 +34,7 @@ def test_run_lifecycle_for_ec2(default_asset_id):
         ]
     aws_access_mock.describe_instance.side_effect = instances_states
     res_gen = run_lifecycle_for_ec2(aws_access_mock, "test_key_file_loc", "test_key", None,
-                                    default_asset_id.tag_value, config.global_config.source_ami_id)
+                                    default_asset_id.tag_value, TEST_DUMMY_AMI_ID)
     res = next(res_gen)
     ec2_instance_description, key_file_loc = res
 
@@ -92,7 +92,7 @@ def test_run_lifecycle_for_ec2_with_context_manager(default_asset_id):
         ]
     aws_access_mock.describe_instance.side_effect = instances_states
     res_gen = run_lifecycle_for_ec2(aws_access_mock, "test_key_file_loc", "test_key", None,
-                                    default_asset_id.tag_value, config.global_config.source_ami_id)
+                                    default_asset_id.tag_value, TEST_DUMMY_AMI_ID)
     with EC2StackLifecycleContextManager(res_gen) as res:
         ec2_instance_description, key_file_location = res
         assert not aws_access_mock.create_new_ec2_key_pair.called

--- a/test/test_run_lifecycle_for_ec2.py
+++ b/test/test_run_lifecycle_for_ec2.py
@@ -2,14 +2,13 @@ from unittest.mock import MagicMock
 
 import pytest
 
-from conftest import TEST_DUMMY_AMI_ID
 from exasol_script_languages_developer_sandbox.lib.aws_access.ec2_instance import EC2Instance
 from exasol_script_languages_developer_sandbox.lib.aws_access.stack_resource import StackResource
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.run_setup_ec2 import run_lifecycle_for_ec2, \
     EC2StackLifecycleContextManager
 
 
-def test_run_lifecycle_for_ec2(default_asset_id):
+def test_run_lifecycle_for_ec2(default_asset_id, test_dummy_ami_id):
     """
     Test that the EC2 deployment and cleanup works as expected. The test calls execute_setup_ec2() and simulates
     the return states from AWS (2x pending, 1x running) for the EC2 instance.
@@ -34,7 +33,7 @@ def test_run_lifecycle_for_ec2(default_asset_id):
         ]
     aws_access_mock.describe_instance.side_effect = instances_states
     res_gen = run_lifecycle_for_ec2(aws_access_mock, "test_key_file_loc", "test_key", None,
-                                    default_asset_id.tag_value, TEST_DUMMY_AMI_ID)
+                                    default_asset_id.tag_value, test_dummy_ami_id)
     res = next(res_gen)
     ec2_instance_description, key_file_loc = res
 
@@ -66,7 +65,7 @@ def test_run_lifecycle_for_ec2(default_asset_id):
         next(res_gen)
 
 
-def test_run_lifecycle_for_ec2_with_context_manager(default_asset_id):
+def test_run_lifecycle_for_ec2_with_context_manager(default_asset_id, test_dummy_ami_id):
     """
     Test that the EC2 deployment and cleanup works as expected, by using the context manager helper class.
     The test calls execute_setup_ec2() and simulates
@@ -92,7 +91,7 @@ def test_run_lifecycle_for_ec2_with_context_manager(default_asset_id):
         ]
     aws_access_mock.describe_instance.side_effect = instances_states
     res_gen = run_lifecycle_for_ec2(aws_access_mock, "test_key_file_loc", "test_key", None,
-                                    default_asset_id.tag_value, TEST_DUMMY_AMI_ID)
+                                    default_asset_id.tag_value, test_dummy_ami_id)
     with EC2StackLifecycleContextManager(res_gen) as res:
         ec2_instance_description, key_file_location = res
         assert not aws_access_mock.create_new_ec2_key_pair.called

--- a/test/test_run_lifecycle_for_ec2.py
+++ b/test/test_run_lifecycle_for_ec2.py
@@ -65,7 +65,7 @@ def test_run_lifecycle_for_ec2(default_asset_id, test_dummy_ami_id):
         next(res_gen)
 
 
-def test_run_lifecycle_for_ec2_with_context_manager(default_asset_id, test_dummy_ami_id):
+def test_run_lifecycle_for_ec2_with_context_manager(default_asset_id, test_dummy_ami_id, test_config):
     """
     Test that the EC2 deployment and cleanup works as expected, by using the context manager helper class.
     The test calls execute_setup_ec2() and simulates
@@ -92,7 +92,7 @@ def test_run_lifecycle_for_ec2_with_context_manager(default_asset_id, test_dummy
     aws_access_mock.describe_instance.side_effect = instances_states
     res_gen = run_lifecycle_for_ec2(aws_access_mock, "test_key_file_loc", "test_key", None,
                                     default_asset_id.tag_value, test_dummy_ami_id)
-    with EC2StackLifecycleContextManager(res_gen) as res:
+    with EC2StackLifecycleContextManager(res_gen, test_config) as res:
         ec2_instance_description, key_file_location = res
         assert not aws_access_mock.create_new_ec2_key_pair.called
         assert aws_access_mock.upload_cloudformation_stack.called

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4,7 +4,7 @@ import pickle
 import traceback
 from pathlib import Path
 
-from exasol_script_languages_developer_sandbox.lib import config
+from conftest import TEST_DUMMY_AMI_ID
 from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.cf_stack import CloudformationStack
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.key_file_manager import KeyFileManager
@@ -59,7 +59,7 @@ def create_cloudformation_stack_and_serialize(tmp_location_key_manager: Path, tm
             pickle.dump(key_file_manager, f)
         cloudformation = CloudformationStack(aws_access, key_file_manager.key_name,
                                              aws_access.get_user(), None, default_asset_id.tag_value,
-                                             config.global_config.source_ami_id)
+                                             TEST_DUMMY_AMI_ID)
         cloudformation.upload_cloudformation_stack()
         with open(tmp_location_cloudformation, "wb") as f:
             pickle.dump(cloudformation, f)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -4,7 +4,6 @@ import pickle
 import traceback
 from pathlib import Path
 
-from conftest import TEST_DUMMY_AMI_ID
 from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.cf_stack import CloudformationStack
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.key_file_manager import KeyFileManager
@@ -50,7 +49,8 @@ def test_keypair_manager_with_local_stack(tmp_path, local_stack, default_asset_i
 
 
 def create_cloudformation_stack_and_serialize(tmp_location_key_manager: Path, tmp_location_cloudformation: Path,
-                                              q: mp.Queue, default_asset_id: AssetId):
+                                              q: mp.Queue, default_asset_id: AssetId,
+                                              test_dummy_ami_id: str):
     try:
         aws_access = AwsLocalStackAccess(None)
         key_file_manager = KeyFileManager(aws_access, None, None, default_asset_id.tag_value)
@@ -59,7 +59,7 @@ def create_cloudformation_stack_and_serialize(tmp_location_key_manager: Path, tm
             pickle.dump(key_file_manager, f)
         cloudformation = CloudformationStack(aws_access, key_file_manager.key_name,
                                              aws_access.get_user(), None, default_asset_id.tag_value,
-                                             TEST_DUMMY_AMI_ID)
+                                             test_dummy_ami_id)
         cloudformation.upload_cloudformation_stack()
         with open(tmp_location_cloudformation, "wb") as f:
             pickle.dump(cloudformation, f)

--- a/test/test_serialization.py
+++ b/test/test_serialization.py
@@ -70,7 +70,7 @@ def create_cloudformation_stack_and_serialize(tmp_location_key_manager: Path, tm
         raise e
 
 
-def test_cloudformation_stack_with_local_stack(tmp_path, local_stack, default_asset_id):
+def test_cloudformation_stack_with_local_stack(tmp_path, local_stack, default_asset_id, test_dummy_ami_id):
     """
     Test that serialization and deserialization of CloudformationStack work!
     """
@@ -78,7 +78,7 @@ def test_cloudformation_stack_with_local_stack(tmp_path, local_stack, default_as
     tmp_file_cloud_formation = Path(tmp_path) / "cloudformation.data"
     q = mp.Queue()
     p = mp.Process(target=create_cloudformation_stack_and_serialize,
-                   args=(tmp_file_key_file, tmp_file_cloud_formation, q, default_asset_id))
+                   args=(tmp_file_key_file, tmp_file_cloud_formation, q, default_asset_id, test_dummy_ami_id))
     p.start()
     p.join()
     assert p.exitcode == 0

--- a/test/test_source_ami.py
+++ b/test/test_source_ami.py
@@ -994,13 +994,13 @@ mock_data = [
 ]
 
 
-def test_find_source_ami_returns_latest_ami():
+def test_find_source_ami_returns_latest_ami(test_config):
     """
     Test that find_source_ami returns the latest AMI image based on the filters given in the global config.
     """
     aws_mock = MagicMock()
     aws_mock.list_amis.return_value = mock_data
-    latest_ami = find_source_ami(aws_mock, config.global_config.source_ami_filters)
+    latest_ami = find_source_ami(aws_mock, test_config.source_ami_filters)
     # ami-0d203747b007677da is the latest one in the mock data
     assert latest_ami.id == "ami-0d203747b007677da"
 

--- a/test/test_source_ami.py
+++ b/test/test_source_ami.py
@@ -1,0 +1,1006 @@
+from unittest.mock import MagicMock
+
+from exasol_script_languages_developer_sandbox.lib import config
+from exasol_script_languages_developer_sandbox.lib.aws_access.ami import Ami
+from exasol_script_languages_developer_sandbox.lib.setup_ec2.source_ami import find_source_ami
+
+# The following is just a dump of data returned from aws cli:
+# 'aws ec2 --profile exa_individual_mfa describe-images --filters Name=name,Values=ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-* --owners 099720109477'
+mock_data = [
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2020-10-14T16:39:06.000Z",
+        "ImageId": "ami-056114420b6ed624e",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201014",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0dfed1ba04750714c",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2020-10-14",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201014",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2022-10-14T16:39:06.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2022-03-31T21:03:35.000Z",
+        "ImageId": "ami-0d672276deff62a7b",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220331",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-076e6ea4ec3f46bb3",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2022-03-31",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220331",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-03-31T21:03:35.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2020-10-27T01:02:32.000Z",
+        "ImageId": "ami-0502e817a62226e03",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-06c551c41e4bc2f56",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2020-10-26",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201026",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2022-10-27T01:02:32.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2021-01-09T01:45:55.000Z",
+        "ImageId": "ami-0bb75d95f668ff5a7",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210108",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0ed4e5f13a8efbc41",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-01-08",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210108",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2023-01-09T01:45:55.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2020-12-03T18:45:56.000Z",
+        "ImageId": "ami-064bd5aa0a25234f1",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201201",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-08ef88ec7a11e3f73",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2020-12-01",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20201201",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2022-12-03T18:45:56.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2021-08-21T00:03:49.000Z",
+        "ImageId": "ami-089550b3658b806d5",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210820",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0eba500f0bfd7e08a",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-08-20",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210820",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2023-08-21T00:03:49.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2021-04-14T00:57:47.000Z",
+        "ImageId": "ami-050c57054a945f865",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210413",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0a286dc481a86d732",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-04-13",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210413",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2023-04-14T00:57:47.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2022-03-03T20:20:46.000Z",
+        "ImageId": "ami-0ccc52d1499699b6b",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220302",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0fe9c09274bc13f82",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2022-03-02",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220302",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-03-03T20:20:46.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2020-09-25T01:16:48.000Z",
+        "ImageId": "ami-00caf1798495a2300",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200924",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0a030876d79c6aff6",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2020-09-24",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200924",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2022-09-25T01:16:48.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2020-09-04T22:46:25.000Z",
+        "ImageId": "ami-05d68e6d48a41210f",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200903",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0218d3ded1b315754",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2020-09-03",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200903",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2022-09-04T22:46:25.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2021-05-04T00:36:32.000Z",
+        "ImageId": "ami-0e4c7d981c4817239",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210503",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0856978de4f22730c",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-05-03",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210503",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2023-05-04T00:36:32.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2021-04-16T05:34:55.000Z",
+        "ImageId": "ami-0848da720bb07de35",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210415",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0d5245055e71e7e47",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-04-15",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210415",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2023-04-16T05:34:55.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2021-08-25T23:55:00.000Z",
+        "ImageId": "ami-0b063c60b220a0574",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210825",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-09f33d01324963fec",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-08-25",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210825",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2023-08-25T23:55:00.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2022-06-28T00:51:13.000Z",
+        "ImageId": "ami-0d203747b007677da",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220627.1",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0f36ed9157a99fd48",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2022-06-27",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220627.1",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-06-28T00:51:13.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2021-09-28T00:25:39.000Z",
+        "ImageId": "ami-0afc0414aefc9eaa7",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210927",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0422f57150a61fa5d",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-09-27",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210927",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2023-09-28T00:25:39.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2021-02-24T18:24:51.000Z",
+        "ImageId": "ami-0767046d1677be5a0",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210223",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-07c3e864b523cd314",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-02-23",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210223",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2023-02-24T18:24:51.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2022-05-24T02:07:16.000Z",
+        "ImageId": "ami-092f628832a8d22a5",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220523",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0c99b870e2bd583f4",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2022-05-23",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220523",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-05-24T02:07:16.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2021-10-16T00:09:47.000Z",
+        "ImageId": "ami-0358b49d1ab873c60",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20211015",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0068aa0941bee3086",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-10-15",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20211015",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2023-10-16T00:09:47.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2021-03-16T00:50:51.000Z",
+        "ImageId": "ami-0dca0d6d4f591c2f4",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210315",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-060b798dc92784a0f",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2021-03-15",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20210315",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2023-03-16T00:50:51.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2022-06-10T11:47:47.000Z",
+        "ImageId": "ami-0c9354388bb36c088",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220610",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-093bd6f21a1452dac",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2022-06-10",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220610",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-06-10T11:47:47.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2022-03-08T23:53:39.000Z",
+        "ImageId": "ami-0498a49a15494604f",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220308",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-05b0f8d9dbc9a7d24",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2022-03-08",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220308",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-03-08T23:53:39.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2020-09-08T00:56:08.000Z",
+        "ImageId": "ami-0c960b947cbb2dd16",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0e55257c35999fffb",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2020-09-07",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200907",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2022-09-08T00:56:08.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2022-04-05T00:51:16.000Z",
+        "ImageId": "ami-0ca64d1b4e674f837",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220404",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0e2aa065b7002c40e",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2022-04-04",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20220404",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2024-04-05T00:51:16.000Z"
+    }),
+    Ami({
+        "Architecture": "x86_64",
+        "CreationDate": "2020-09-17T16:24:38.000Z",
+        "ImageId": "ami-052eaddc8881bf2ec",
+        "ImageLocation": "099720109477/ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200916",
+        "ImageType": "machine",
+        "Public": True,
+        "OwnerId": "099720109477",
+        "PlatformDetails": "Linux/UNIX",
+        "UsageOperation": "RunInstances",
+        "State": "available",
+        "BlockDeviceMappings": [
+            {
+                "DeviceName": "/dev/sda1",
+                "Ebs": {
+                    "DeleteOnTermination": True,
+                    "SnapshotId": "snap-0a31b4b0ef89e280e",
+                    "VolumeSize": 8,
+                    "VolumeType": "gp2",
+                    "Encrypted": False
+                }
+            },
+            {
+                "DeviceName": "/dev/sdb",
+                "VirtualName": "ephemeral0"
+            },
+            {
+                "DeviceName": "/dev/sdc",
+                "VirtualName": "ephemeral1"
+            }
+        ],
+        "Description": "Canonical, Ubuntu, 20.04 LTS, amd64 focal image build on 2020-09-16",
+        "EnaSupport": True,
+        "Hypervisor": "xen",
+        "Name": "ubuntu/images/hvm-ssd/ubuntu-focal-20.04-amd64-server-20200916",
+        "RootDeviceName": "/dev/sda1",
+        "RootDeviceType": "ebs",
+        "SriovNetSupport": "simple",
+        "VirtualizationType": "hvm",
+        "DeprecationTime": "2022-09-17T16:24:38.000Z"
+    }),
+]
+
+
+def test_find_source_ami_returns_latest_ami():
+    """
+    Test that find_source_ami returns the latest AMI image based on the filters given in the global config.
+    """
+    aws_mock = MagicMock()
+    aws_mock.list_amis.return_value = mock_data
+    latest_ami = find_source_ami(aws_mock, config.global_config.source_ami_filters)
+    # ami-0d203747b007677da is the latest one in the mock data
+    assert latest_ami.id == "ami-0d203747b007677da"
+


### PR DESCRIPTION
fixes #26 

1. use existing function AwsAccess.list_amis() to get all AMI's, filtered for a specific name prefix (Ubuntu 20.04 name) and other attributes; then use latest AMI's from that list
2. refactored config handling: Inject the config object in click functions and tests, instead of using the global variable.
3. Added a test with mock data (which is actually real data returned from `aws cli`)