### PR TITLE
#12: Updated the script-languages-release tag with the correct version

### DIFF
--- a/doc/changes/changes_0.1.0.md
+++ b/doc/changes/changes_0.1.0.md
@@ -27,3 +27,4 @@ n/a
 
  - #22: Improved logging
  - #26: Implemented search for latest AMI
+ - #12: Updated the script-languages-release tag with the correct version

--- a/exasol_script_languages_developer_sandbox/cli/commands/install_dependencies.py
+++ b/exasol_script_languages_developer_sandbox/cli/commands/install_dependencies.py
@@ -3,6 +3,7 @@ from exasol_script_languages_developer_sandbox.cli.common import add_options
 from exasol_script_languages_developer_sandbox.cli.options.ec2_options import ec2_host_options
 from exasol_script_languages_developer_sandbox.cli.options.logging import logging_options
 from exasol_script_languages_developer_sandbox.lib.ansible.ansible_access import AnsibleAccess
+from exasol_script_languages_developer_sandbox.lib.config import default_config
 from exasol_script_languages_developer_sandbox.lib.logging import set_log_level
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.host_info import HostInfo
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.run_install_dependencies import run_install_dependencies
@@ -19,4 +20,4 @@ def install_dependencies(
     Debug command to ansible-installation onto an EC-2 instance.
     """
     set_log_level(log_level)
-    run_install_dependencies(AnsibleAccess(), (HostInfo(host_name, ssh_private_key),))
+    run_install_dependencies(AnsibleAccess(), default_config, (HostInfo(host_name, ssh_private_key),))

--- a/exasol_script_languages_developer_sandbox/cli/options/id_options.py
+++ b/exasol_script_languages_developer_sandbox/cli/options/id_options.py
@@ -1,10 +1,9 @@
 import click
-from importlib_metadata import version
 
-DEFAULT_ID = version("exasol_script_languages_release")
+from exasol_script_languages_developer_sandbox.lib.config import SLC_VERSION
 
 id_options = [
-              click.option('--asset-id', type=str, default=DEFAULT_ID,
+              click.option('--asset-id', type=str, default=SLC_VERSION,
                            help="This value will be used in the AMI name, as tag on all AWS resources "
                                 "and in the prefix of the S3 objects.")
 ]

--- a/exasol_script_languages_developer_sandbox/lib/config.py
+++ b/exasol_script_languages_developer_sandbox/lib/config.py
@@ -1,3 +1,6 @@
+from importlib_metadata import version
+
+SLC_VERSION = version("exasol_script_languages_release")
 
 default_config = {
     "time_to_wait_for_polling": 10.0,
@@ -7,7 +10,8 @@ default_config = {
         "owner-id": "099720109477",
         "architecture": "x86_64",
         "state": "available"
-    }
+    },
+    "slc_version": SLC_VERSION
 }
 
 

--- a/exasol_script_languages_developer_sandbox/lib/run_create_vm.py
+++ b/exasol_script_languages_developer_sandbox/lib/run_create_vm.py
@@ -54,7 +54,7 @@ def run_create_vm(aws_access: AwsAccess, ec2_key_file: Optional[str], ec2_key_na
         time.sleep(configuration.time_to_wait_for_polling)
 
         host_name = ec2_instance_description.public_dns_name
-        run_install_dependencies(ansible_access, (HostInfo(host_name, key_file_location),),
+        run_install_dependencies(ansible_access, configuration, (HostInfo(host_name, key_file_location),),
                                  ansible_run_context, ansible_repositories)
         run_reset_password(ansible_access, default_password,
                            (HostInfo(host_name, key_file_location),), ansible_reset_password_context,

--- a/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_install_dependencies.py
+++ b/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_install_dependencies.py
@@ -1,3 +1,4 @@
+from importlib.metadata import version
 from typing import Tuple
 
 from exasol_script_languages_developer_sandbox.lib.ansible.ansible_access import AnsibleAccess
@@ -6,11 +7,14 @@ from exasol_script_languages_developer_sandbox.lib.ansible.ansible_repository im
     default_repositories
 from exasol_script_languages_developer_sandbox.lib.ansible.ansible_run_context import AnsibleRunContext, \
     default_ansible_run_context
+from exasol_script_languages_developer_sandbox.lib.config import ConfigObject
 
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.host_info import HostInfo
 
 
-def run_install_dependencies(ansible_access: AnsibleAccess, host_infos: Tuple[HostInfo, ...] = tuple(),
+def run_install_dependencies(ansible_access: AnsibleAccess,
+                             configuration: ConfigObject,
+                             host_infos: Tuple[HostInfo, ...] = tuple(),
                              ansible_run_context: AnsibleRunContext = default_ansible_run_context,
                              ansible_repositories: Tuple[AnsibleRepository, ...] = default_repositories) -> None:
     """
@@ -20,10 +24,7 @@ def run_install_dependencies(ansible_access: AnsibleAccess, host_infos: Tuple[Ho
     are copied as flat copy to the dynamic working copy, too.
     The playbook is indicated by variable ansible_run_context, which also might contain additional ansible variables.
     """
-    # TODO: Awaiting release 5.0.0 of slc!!!
-    # Check https://github.com/exasol/script-languages-developer-sandbox/issues/12)
-    # new_extra_vars = {"slc_version": meta.version("exasol_script_languages_release")}
-    new_extra_vars = {"slc_version": "master"}
+    new_extra_vars = {"slc_version": configuration.slc_version}
     if ansible_run_context.extra_vars is not None:
         new_extra_vars.update(ansible_run_context.extra_vars)
     new_ansible_run_context = AnsibleRunContext(ansible_run_context.playbook, new_extra_vars)

--- a/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2_and_install_dependencies.py
+++ b/exasol_script_languages_developer_sandbox/lib/setup_ec2/run_setup_ec2_and_install_dependencies.py
@@ -52,7 +52,8 @@ def run_setup_ec2_and_install_dependencies(aws_access: AwsAccess,
         time.sleep(configuration.time_to_wait_for_polling)
         host_name = ec2_instance_description.public_dns_name
         try:
-            run_install_dependencies(ansible_access, (HostInfo(host_name, key_file_location),),
+            run_install_dependencies(ansible_access, configuration,
+                                     (HostInfo(host_name, key_file_location),),
                                      ansible_run_context, ansible_repositories)
         except Exception as e:
             LOG.exception("Install dependencies failed.")

--- a/poetry.lock
+++ b/poetry.lock
@@ -1,13 +1,13 @@
 [[package]]
 name = "ansible"
-version = "6.2.0"
+version = "6.3.0"
 description = "Radically simple IT automation"
 category = "main"
 optional = false
 python-versions = ">=3.8"
 
 [package.dependencies]
-ansible-core = ">=2.13.2,<2.14.0"
+ansible-core = ">=2.13.3,<2.14.0"
 
 [[package]]
 name = "ansible-core"
@@ -48,13 +48,13 @@ optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-dev = ["PyYAML (>=3.10)", "prance[osv] (>=0.11)", "marshmallow (>=3.13.0)", "pytest", "mock", "flake8 (==4.0.1)", "flake8-bugbear (==22.4.25)", "pre-commit (>=2.4,<3.0)", "mypy (==0.950)", "types-pyyaml", "tox"]
+tests = ["PyYAML (>=3.10)", "prance[osv] (>=0.11)", "marshmallow (>=3.13.0)", "pytest", "mock"]
+marshmallow = ["marshmallow (>=3.13.0)"]
 docs = ["marshmallow (>=3.13.0)", "pyyaml (==6.0)", "sphinx (==4.5.0)", "sphinx-issues (==3.0.1)", "sphinx-rtd-theme (==1.0.0)"]
 lint = ["flake8 (==4.0.1)", "flake8-bugbear (==22.4.25)", "pre-commit (>=2.4,<3.0)", "mypy (==0.950)", "types-pyyaml"]
-marshmallow = ["marshmallow (>=3.13.0)"]
-tests = ["PyYAML (>=3.10)", "prance[osv] (>=0.11)", "marshmallow (>=3.13.0)", "pytest", "mock"]
-validation = ["prance[osv] (>=0.11)"]
+dev = ["PyYAML (>=3.10)", "prance[osv] (>=0.11)", "marshmallow (>=3.13.0)", "pytest", "mock", "flake8 (==4.0.1)", "flake8-bugbear (==22.4.25)", "pre-commit (>=2.4,<3.0)", "mypy (==0.950)", "types-pyyaml", "tox"]
 yaml = ["PyYAML (>=3.10)"]
+validation = ["prance[osv] (>=0.11)"]
 
 [[package]]
 name = "atomicwrites"
@@ -73,10 +73,10 @@ optional = false
 python-versions = ">=3.5"
 
 [package.extras]
-dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 docs = ["furo", "sphinx", "zope.interface", "sphinx-notfound-page"]
 tests = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "cloudpickle"]
 tests_no_zope = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "cloudpickle"]
+dev = ["coverage[toml] (>=5.0.2)", "hypothesis", "pympler", "pytest (>=4.3.0)", "mypy (>=0.900,!=0.940)", "pytest-mypy-plugins", "zope.interface", "furo", "sphinx", "sphinx-notfound-page", "pre-commit", "cloudpickle"]
 
 [[package]]
 name = "aws-sam-translator"
@@ -95,29 +95,26 @@ dev = ["coverage (>=5.3,<6.0)", "flake8 (>=3.8.4,<3.9.0)", "tox (>=3.24,<4.0)", 
 
 [[package]]
 name = "bcrypt"
-version = "3.2.2"
+version = "4.0.0"
 description = "Modern password hashing for your software and your servers"
 category = "dev"
 optional = false
 python-versions = ">=3.6"
 
-[package.dependencies]
-cffi = ">=1.1"
-
 [package.extras]
-tests = ["pytest (>=3.2.1,!=3.3.0)"]
 typecheck = ["mypy"]
+tests = ["pytest (>=3.2.1,!=3.3.0)"]
 
 [[package]]
 name = "boto3"
-version = "1.24.57"
+version = "1.24.60"
 description = "The AWS SDK for Python"
 category = "main"
 optional = false
 python-versions = ">= 3.7"
 
 [package.dependencies]
-botocore = ">=1.27.57,<1.28.0"
+botocore = ">=1.27.60,<1.28.0"
 jmespath = ">=0.7.1,<2.0.0"
 s3transfer = ">=0.6.0,<0.7.0"
 
@@ -126,7 +123,7 @@ crt = ["botocore[crt] (>=1.21.0,<2.0a0)"]
 
 [[package]]
 name = "botocore"
-version = "1.27.57"
+version = "1.27.60"
 description = "Low-level, data-driven core of boto 3."
 category = "main"
 optional = false
@@ -235,11 +232,11 @@ python-versions = ">=3.6"
 cffi = ">=1.12"
 
 [package.extras]
-docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
-docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
 pep8test = ["black", "flake8", "flake8-import-order", "pep8-naming"]
+docstest = ["pyenchant (>=1.6.11)", "twine (>=1.12.0)", "sphinxcontrib-spelling (>=4.0.1)"]
 sdist = ["setuptools_rust (>=0.11.4)"]
 ssh = ["bcrypt (>=3.1.5)"]
+docs = ["sphinx (>=1.6.5,!=1.8.0,!=3.1.0,!=3.1.1)", "sphinx-rtd-theme"]
 test = ["pytest (>=6.2.0)", "pytest-benchmark", "pytest-cov", "pytest-subtests", "pytest-xdist", "pretend", "iso8601", "pytz", "hypothesis (>=1.11.4,!=3.79.2)"]
 
 [[package]]
@@ -298,12 +295,12 @@ optional = false
 python-versions = ">=3.6,<4.0"
 
 [package.extras]
-dnssec = ["cryptography (>=2.6,<37.0)"]
-curio = ["curio (>=1.2,<2.0)", "sniffio (>=1.1,<2.0)"]
 doh = ["h2 (>=4.1.0)", "httpx (>=0.21.1)", "requests (>=2.23.0,<3.0.0)", "requests-toolbelt (>=0.9.1,<0.10.0)"]
-idna = ["idna (>=2.1,<4.0)"]
+dnssec = ["cryptography (>=2.6,<37.0)"]
 trio = ["trio (>=0.14,<0.20)"]
 wmi = ["wmi (>=1.5.1,<2.0.0)"]
+curio = ["curio (>=1.2,<2.0)", "sniffio (>=1.1,<2.0)"]
+idna = ["idna (>=2.1,<4.0)"]
 
 [[package]]
 name = "docker"
@@ -318,8 +315,8 @@ requests = ">=2.14.2,<2.18.0 || >2.18.0"
 websocket-client = ">=0.32.0"
 
 [package.extras]
-ssh = ["paramiko (>=2.4.2)"]
 tls = ["pyOpenSSL (>=17.5.0)", "cryptography (>=3.4.7)", "idna (>=2.0.0)"]
+ssh = ["paramiko (>=2.4.2)"]
 
 [[package]]
 name = "docutils"
@@ -341,8 +338,8 @@ python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 six = ">=1.9.0"
 
 [package.extras]
-gmpy = ["gmpy"]
 gmpy2 = ["gmpy2"]
+gmpy = ["gmpy"]
 
 [[package]]
 name = "exasol-error-reporting-python"
@@ -443,7 +440,7 @@ type = "url"
 url = "https://github.com/exasol/script-languages-container-tool/releases/download/0.14.0/exasol_script_languages_container_tool-0.14.0-py3-none-any.whl"
 [[package]]
 name = "exasol-script-languages-release"
-version = "6.0.0"
+version = "5.0.0"
 description = "Script Languages Release"
 category = "main"
 optional = false
@@ -458,8 +455,8 @@ exasol_script_languages_container_tool = {url = "https://github.com/exasol/scrip
 [package.source]
 type = "git"
 url = "https://github.com/exasol/script-languages-release.git"
-reference = "develop"
-resolved_reference = "2d79762ff8ed4aa9669a75206798fb3e4230ada6"
+reference = "5.0.0"
+resolved_reference = "f56c64c52a91b3d5fcf45d6f11330b5825198b79"
 
 [[package]]
 name = "fabric"
@@ -532,8 +529,8 @@ zipp = ">=0.5"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=9)", "rst.linker (>=1.9)"]
-perf = ["ipython"]
 testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-cov", "pytest-enabler (>=1.3)", "packaging", "pyfakefs", "flufl.flake8", "pytest-perf (>=0.9.2)", "pytest-black (>=0.3.7)", "pytest-mypy (>=0.9.1)", "importlib-resources (>=1.3)"]
+perf = ["ipython"]
 
 [[package]]
 name = "importlib-resources"
@@ -622,8 +619,8 @@ python-versions = ">=2.7"
 
 [package.extras]
 docs = ["sphinx", "jaraco.packaging (>=3.2)", "rst.linker (>=1.9)"]
-testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-black-multipy", "pytest-cov", "ecdsa", "feedparser", "numpy", "pandas", "pymongo", "scikit-learn", "sqlalchemy", "pytest-flake8 (<1.1.0)", "enum34", "jsonlib", "pytest-flake8 (>=1.1.1)"]
 "testing.libs" = ["simplejson", "ujson", "yajl"]
+testing = ["pytest (>=3.5,!=3.7.3)", "pytest-checkdocs (>=1.2.3)", "pytest-black-multipy", "pytest-cov", "ecdsa", "feedparser", "numpy", "pandas", "pymongo", "scikit-learn", "sqlalchemy", "pytest-flake8 (<1.1.0)", "enum34", "jsonlib", "pytest-flake8 (>=1.1.1)"]
 
 [[package]]
 name = "jsonpointer"
@@ -647,8 +644,8 @@ pyrsistent = ">=0.14.0"
 six = ">=1.11.0"
 
 [package.extras]
-format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
 format_nongpl = ["idna", "jsonpointer (>1.13)", "webcolors", "rfc3986-validator (>0.1.0)", "rfc3339-validator"]
+format = ["idna", "jsonpointer (>1.13)", "rfc3987", "strict-rfc3339", "webcolors"]
 
 [[package]]
 name = "junit-xml"
@@ -687,10 +684,10 @@ stevedore = ">=3.4.0"
 tailer = ">=0.4.1"
 
 [package.extras]
-dev = ["black (==22.3.0)", "coveralls (==3.1.0)", "cython", "flake8 (>=3.6.0)", "flake8-black (==0.3.2)", "flake8-isort (>=4.0.0)", "flake8-quotes (>=0.11.0)", "pre-commit (==2.13.0)", "pyproject-flake8", "isort (==5.9.1)", "pandoc", "pypandoc", "autoflake"]
-full = ["airspeed (==0.5.19)", "amazon-kclpy-ext (==1.5.1)", "aws-sam-translator (>=1.15.1)", "awscli (>=1.22.90)", "boto (>=2.49.0)", "botocore (>=1.12.13)", "cbor2 (>=5.2.0)", "crontab (>=0.22.6)", "cryptography", "docker (==5.0.0)", "flask (>=1.0.2)", "flask-cors (>=3.0.3,<3.1.0)", "flask-swagger (==0.2.12)", "jsonpatch (>=1.24,<2.0)", "jsonpath-rw (>=1.4.0,<2.0.0)", "localstack-ext[runtime] (==0.14.5)", "moto-ext[all] (==3.1.12)", "opensearch-py (==1.1.0)", "pproxy (>=2.7.0)", "pyopenssl (>=21.0.0)", "Quart (>=0.6.15)", "readerwriterlock (>=1.0.7)", "requests-aws4auth (==0.9)", "Werkzeug (>=2.0)", "xmltodict (>=0.11.0)"]
-runtime = ["airspeed (==0.5.19)", "amazon-kclpy-ext (==1.5.1)", "aws-sam-translator (>=1.15.1)", "awscli (>=1.22.90)", "boto (>=2.49.0)", "botocore (>=1.12.13)", "cbor2 (>=5.2.0)", "crontab (>=0.22.6)", "cryptography", "docker (==5.0.0)", "flask (>=1.0.2)", "flask-cors (>=3.0.3,<3.1.0)", "flask-swagger (==0.2.12)", "jsonpatch (>=1.24,<2.0)", "jsonpath-rw (>=1.4.0,<2.0.0)", "localstack-ext[runtime] (==0.14.5)", "moto-ext[all] (==3.1.12)", "opensearch-py (==1.1.0)", "pproxy (>=2.7.0)", "pyopenssl (>=21.0.0)", "Quart (>=0.6.15)", "readerwriterlock (>=1.0.7)", "requests-aws4auth (==0.9)", "Werkzeug (>=2.0)", "xmltodict (>=0.11.0)"]
 test = ["coverage[toml] (>=5.5)", "deepdiff (>=5.5.0)", "jsonpath-ng (>=1.5.3)", "pytest (==6.2.4)", "pytest-httpserver (>=1.0.1)", "pytest-rerunfailures (==10.0)"]
+full = ["airspeed (==0.5.19)", "amazon-kclpy-ext (==1.5.1)", "aws-sam-translator (>=1.15.1)", "awscli (>=1.22.90)", "boto (>=2.49.0)", "botocore (>=1.12.13)", "cbor2 (>=5.2.0)", "crontab (>=0.22.6)", "cryptography", "docker (==5.0.0)", "flask (>=1.0.2)", "flask-cors (>=3.0.3,<3.1.0)", "flask-swagger (==0.2.12)", "jsonpatch (>=1.24,<2.0)", "jsonpath-rw (>=1.4.0,<2.0.0)", "localstack-ext[runtime] (==0.14.5)", "moto-ext[all] (==3.1.12)", "opensearch-py (==1.1.0)", "pproxy (>=2.7.0)", "pyopenssl (>=21.0.0)", "Quart (>=0.6.15)", "readerwriterlock (>=1.0.7)", "requests-aws4auth (==0.9)", "Werkzeug (>=2.0)", "xmltodict (>=0.11.0)"]
+dev = ["black (==22.3.0)", "coveralls (==3.1.0)", "cython", "flake8 (>=3.6.0)", "flake8-black (==0.3.2)", "flake8-isort (>=4.0.0)", "flake8-quotes (>=0.11.0)", "pre-commit (==2.13.0)", "pyproject-flake8", "isort (==5.9.1)", "pandoc", "pypandoc", "autoflake"]
+runtime = ["airspeed (==0.5.19)", "amazon-kclpy-ext (==1.5.1)", "aws-sam-translator (>=1.15.1)", "awscli (>=1.22.90)", "boto (>=2.49.0)", "botocore (>=1.12.13)", "cbor2 (>=5.2.0)", "crontab (>=0.22.6)", "cryptography", "docker (==5.0.0)", "flask (>=1.0.2)", "flask-cors (>=3.0.3,<3.1.0)", "flask-swagger (==0.2.12)", "jsonpatch (>=1.24,<2.0)", "jsonpath-rw (>=1.4.0,<2.0.0)", "localstack-ext[runtime] (==0.14.5)", "moto-ext[all] (==3.1.12)", "opensearch-py (==1.1.0)", "pproxy (>=2.7.0)", "pyopenssl (>=21.0.0)", "Quart (>=0.6.15)", "readerwriterlock (>=1.0.7)", "requests-aws4auth (==0.9)", "Werkzeug (>=2.0)", "xmltodict (>=0.11.0)"]
 
 [[package]]
 name = "localstack-client"
@@ -727,11 +724,11 @@ requests = ">=2.20.0,<2.26"
 tabulate = "*"
 
 [package.extras]
-package = ["python-minifier"]
-runtime = ["avro (>=1.11.0)", "amazon.ion (==0.8)", "aws-encryption-sdk (>=3.1.0)", "dirtyjson (==1.0.7)", "docker-registry-client (>=0.5.2)", "docker (==5.0.0)", "dulwich (>=0.19.16)", "flask (>=1.0.2)", "graphql-core (>=3.0.3)", "janus (>=0.5.0)", "jsonpatch (>=1.32)", "Js2Py (>=0.71)", "kafka-python", "kubernetes (==21.7.0)", "localstack[runtime] (>=0.14.3.4)", "moto-ext[all] (>=3.1.12)", "paho-mqtt (>=1.5)", "parse (==1.19.0)", "parquet (>=1.3.1)", "pg8000 (>=1.10)", "postgres (>=2.2.2)", "postgresql-proxy (>=0.0.1)", "presto-python-client (>=0.7.0)", "pyftpdlib (>=1.5.6)", "pyhive[hive] (>=0.6.1)", "pyion2json (>=0.0.2)", "PyJWT (>=1.7.0)", "pyqldb (>=3.2,<4.0)", "python-snappy (>=0.6)", "readerwriterlock (>=1.0.7)", "rsa (>=4.0)", "sql-metadata (>=2.6.0)", "srp-ext (==1.0.7.1)", "testing.common.database (>=1.1.0)", "tornado (>=6.0)", "warrant-ext (>=0.6.2)", "websockets (>=8.1)", "Whoosh (>=2.7.4)"]
 test = ["aiohttp", "appdirs", "aws_xray_sdk (>=2.4.2)", "azure-common (>=1.1.26)", "azure-core (>=1.9.0)", "azure-devops (>=6.0.0b4)", "azure-functions (>=1.5.0)", "azure-identity (>=1.5.0)", "azure-mgmt-core (>=1.2.2)", "azure-mgmt-storage (>=16.0.0)", "azure-mgmt-web (>=1.0.0)", "azure-servicebus (>=7.0.1)", "azure-storage-blob (>=12.3.0)", "azure-storage-queue (>=12.1.1)", "black (==22.3.0)", "coverage[toml] (>=5.0.0)", "coveralls", "flake8-black (==0.3.2)", "flake8-isort (>=4.0.0)", "flake8-quotes (>=0.11.0)", "flake8 (==3.9.2)", "gremlinpython (==3.5.1)", "isort (==5.9.1)", "Js2Py (>=0.71)", "jws (>=0.1.3)", "localstack[test] (>=0.14.3.2)", "msal", "msal-extensions", "msrest", "nest-asyncio (>=1.4.1)", "paramiko (>=2.11.0,<2.12.0)", "portalocker", "pre-commit (==2.13.0)", "pyarrow", "pykafka", "pymongo", "pymssql", "pymysql", "pyproject-flake8", "pytest-dependency (==0.5.1)", "pytest-httpserver (>=1.0.1)", "pytest-instafail (>=0.4.2)", "pytest-rerunfailures (==10.0)", "pytest (==6.2.4)", "redis (==3.3.7)", "redshift-connector"]
 test_ext = ["pyathena"]
+runtime = ["avro (>=1.11.0)", "amazon.ion (==0.8)", "aws-encryption-sdk (>=3.1.0)", "dirtyjson (==1.0.7)", "docker-registry-client (>=0.5.2)", "docker (==5.0.0)", "dulwich (>=0.19.16)", "flask (>=1.0.2)", "graphql-core (>=3.0.3)", "janus (>=0.5.0)", "jsonpatch (>=1.32)", "Js2Py (>=0.71)", "kafka-python", "kubernetes (==21.7.0)", "localstack[runtime] (>=0.14.3.4)", "moto-ext[all] (>=3.1.12)", "paho-mqtt (>=1.5)", "parse (==1.19.0)", "parquet (>=1.3.1)", "pg8000 (>=1.10)", "postgres (>=2.2.2)", "postgresql-proxy (>=0.0.1)", "presto-python-client (>=0.7.0)", "pyftpdlib (>=1.5.6)", "pyhive[hive] (>=0.6.1)", "pyion2json (>=0.0.2)", "PyJWT (>=1.7.0)", "pyqldb (>=3.2,<4.0)", "python-snappy (>=0.6)", "readerwriterlock (>=1.0.7)", "rsa (>=4.0)", "sql-metadata (>=2.6.0)", "srp-ext (==1.0.7.1)", "testing.common.database (>=1.1.0)", "tornado (>=6.0)", "warrant-ext (>=0.6.2)", "websockets (>=8.1)", "Whoosh (>=2.7.4)"]
 test_overrides = ["moto-ext[all] (>=3.1.10)"]
+package = ["python-minifier"]
 
 [[package]]
 name = "lockfile"
@@ -785,10 +782,10 @@ python-versions = ">=3.8"
 
 [package.extras]
 default = ["numpy (>=1.19)", "scipy (>=1.8)", "matplotlib (>=3.4)", "pandas (>=1.3)"]
-developer = ["pre-commit (>=2.20)", "mypy (>=0.961)"]
 doc = ["sphinx (>=5)", "pydata-sphinx-theme (>=0.9)", "sphinx-gallery (>=0.10)", "numpydoc (>=1.4)", "pillow (>=9.1)", "nb2plots (>=0.6)", "texext (>=0.6.6)"]
-extra = ["lxml (>=4.6)", "pygraphviz (>=1.9)", "pydot (>=1.4.2)", "sympy (>=1.10)"]
 test = ["pytest (>=7.1)", "pytest-cov (>=3.0)", "codecov (>=2.1)"]
+developer = ["pre-commit (>=2.20)", "mypy (>=0.961)"]
+extra = ["lxml (>=4.6)", "pygraphviz (>=1.9)", "pydot (>=1.4.2)", "sympy (>=1.10)"]
 
 [[package]]
 name = "numpy"
@@ -856,8 +853,8 @@ pynacl = ">=1.0.1"
 six = "*"
 
 [package.extras]
-all = ["pyasn1 (>=0.1.7)", "pynacl (>=1.0.1)", "bcrypt (>=3.1.3)", "invoke (>=1.3)", "gssapi (>=1.4.1)", "pywin32 (>=2.1.8)"]
 ed25519 = ["pynacl (>=1.0.1)", "bcrypt (>=3.1.3)"]
+all = ["pyasn1 (>=0.1.7)", "pynacl (>=1.0.1)", "bcrypt (>=3.1.3)", "invoke (>=1.3)", "gssapi (>=1.4.1)", "pywin32 (>=2.1.8)"]
 gssapi = ["pyasn1 (>=0.1.7)", "gssapi (>=1.4.1)", "pywin32 (>=2.1.8)"]
 invoke = ["invoke (>=1.3)"]
 
@@ -900,8 +897,8 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-dev = ["pre-commit", "tox"]
 testing = ["pytest", "pytest-benchmark"]
+dev = ["pre-commit", "tox"]
 
 [[package]]
 name = "plux"
@@ -1016,10 +1013,10 @@ optional = false
 python-versions = ">=3.6"
 
 [package.extras]
-crypto = ["cryptography (>=3.3.1)"]
-dev = ["sphinx", "sphinx-rtd-theme", "zope.interface", "cryptography (>=3.3.1)", "pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)", "mypy", "pre-commit"]
 docs = ["sphinx", "sphinx-rtd-theme", "zope.interface"]
 tests = ["pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)"]
+crypto = ["cryptography (>=3.3.1)"]
+dev = ["sphinx", "sphinx-rtd-theme", "zope.interface", "cryptography (>=3.3.1)", "pytest (>=6.0.0,<7.0.0)", "coverage[toml] (==5.0.4)", "mypy", "pre-commit"]
 
 [[package]]
 name = "pynacl"
@@ -1197,10 +1194,10 @@ optional = false
 python-versions = "*"
 
 [package.extras]
-examples = ["html5lib", "packaging", "pygraphviz", "requests"]
-lint = ["black", "flake8", "mypy", "isort", "types-requests"]
 release = ["build", "towncrier", "twine"]
 test = ["commentjson", "packaging", "pytest"]
+lint = ["black", "flake8", "mypy", "isort", "types-requests"]
+examples = ["html5lib", "packaging", "pygraphviz", "requests"]
 
 [[package]]
 name = "rich"
@@ -1383,16 +1380,16 @@ socks = ["PySocks (>=1.5.6,!=1.5.7,<2.0)"]
 
 [[package]]
 name = "websocket-client"
-version = "1.3.3"
+version = "1.4.0"
 description = "WebSocket client for Python with low level API options"
 category = "main"
 optional = false
 python-versions = ">=3.7"
 
 [package.extras]
-docs = ["Sphinx (>=3.4)", "sphinx-rtd-theme (>=0.5)"]
-optional = ["python-socks", "wsaccel"]
 test = ["websockets"]
+docs = ["sphinx-rtd-theme (>=0.5)", "Sphinx (>=3.4)"]
+optional = ["wsaccel", "python-socks"]
 
 [[package]]
 name = "wrapt"
@@ -1417,12 +1414,12 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = ">=3.8.0,<4.0"
-content-hash = "6fc14bab671883835221058dc6506be754da11dca638091626ed2f7c2efde1de"
+content-hash = "dc9b1fed34ecb15e66940d5aacf077f74aaa50ac3fa6dac91973df4ab1b8e56e"
 
 [metadata.files]
 ansible = [
-    {file = "ansible-6.2.0-py3-none-any.whl", hash = "sha256:20625109c4e9c79e9e23bff6d1e32a780d13935007369111261a7ddfd3cf75b1"},
-    {file = "ansible-6.2.0.tar.gz", hash = "sha256:bdaf2b2fd926ff189fbde2fefe7234733f32c36fc413033fa5d93945fbdc06a6"},
+    {file = "ansible-6.3.0-py3-none-any.whl", hash = "sha256:74f5c3bd7441dcdb7cace8a3c2a44b0be7002be346bf8137e5c67fd8ba743fd3"},
+    {file = "ansible-6.3.0.tar.gz", hash = "sha256:d5fa9fc15a8d45c8d5247a9645b0b48f995d735b12c4da655666d48506273526"},
 ]
 ansible-core = [
     {file = "ansible-core-2.13.3.tar.gz", hash = "sha256:eec5042530ff1c0c8d13a36fa047c6dd9157efeefd464a856b4ce38be4cd1988"},
@@ -1449,25 +1446,26 @@ aws-sam-translator = [
     {file = "aws_sam_translator-1.50.0-py3-none-any.whl", hash = "sha256:d375e9333c0262ed74b6d7ae90938060713ab17341f4e06c5cdbfd755902d9b4"},
 ]
 bcrypt = [
-    {file = "bcrypt-3.2.2-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:7180d98a96f00b1050e93f5b0f556e658605dd9f524d0b0e68ae7944673f525e"},
-    {file = "bcrypt-3.2.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:61bae49580dce88095d669226d5076d0b9d927754cedbdf76c6c9f5099ad6f26"},
-    {file = "bcrypt-3.2.2-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:88273d806ab3a50d06bc6a2fc7c87d737dd669b76ad955f449c43095389bc8fb"},
-    {file = "bcrypt-3.2.2-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.manylinux_2_24_x86_64.whl", hash = "sha256:6d2cb9d969bfca5bc08e45864137276e4c3d3d7de2b162171def3d188bf9d34a"},
-    {file = "bcrypt-3.2.2-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2b02d6bfc6336d1094276f3f588aa1225a598e27f8e3388f4db9948cb707b521"},
-    {file = "bcrypt-3.2.2-cp36-abi3-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_12_x86_64.manylinux2010_x86_64.whl", hash = "sha256:a2c46100e315c3a5b90fdc53e429c006c5f962529bc27e1dfd656292c20ccc40"},
-    {file = "bcrypt-3.2.2-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:7d9ba2e41e330d2af4af6b1b6ec9e6128e91343d0b4afb9282e54e5508f31baa"},
-    {file = "bcrypt-3.2.2-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:cd43303d6b8a165c29ec6756afd169faba9396a9472cdff753fe9f19b96ce2fa"},
-    {file = "bcrypt-3.2.2-cp36-abi3-win32.whl", hash = "sha256:4e029cef560967fb0cf4a802bcf4d562d3d6b4b1bf81de5ec1abbe0f1adb027e"},
-    {file = "bcrypt-3.2.2-cp36-abi3-win_amd64.whl", hash = "sha256:7ff2069240c6bbe49109fe84ca80508773a904f5a8cb960e02a977f7f519b129"},
-    {file = "bcrypt-3.2.2.tar.gz", hash = "sha256:433c410c2177057705da2a9f2cd01dd157493b2a7ac14c8593a16b3dab6b6bfb"},
+    {file = "bcrypt-4.0.0-cp36-abi3-macosx_10_10_universal2.whl", hash = "sha256:845b1daf4df2dd94d2fdbc9454953ca9dd0e12970a0bfc9f3dcc6faea3fa96e4"},
+    {file = "bcrypt-4.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.manylinux_2_24_aarch64.whl", hash = "sha256:8780e69f9deec9d60f947b169507d2c9816e4f11548f1f7ebee2af38b9b22ae4"},
+    {file = "bcrypt-4.0.0-cp36-abi3-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1c3334446fac200499e8bc04a530ce3cf0b3d7151e0e4ac5c0dddd3d95e97843"},
+    {file = "bcrypt-4.0.0-cp36-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bfb67f6a6c72dfb0a02f3df51550aa1862708e55128b22543e2b42c74f3620d7"},
+    {file = "bcrypt-4.0.0-cp36-abi3-manylinux_2_24_x86_64.whl", hash = "sha256:7c7dd6c1f05bf89e65261d97ac3a6520f34c2acb369afb57e3ea4449be6ff8fd"},
+    {file = "bcrypt-4.0.0-cp36-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:594780b364fb45f2634c46ec8d3e61c1c0f1811c4f2da60e8eb15594ecbf93ed"},
+    {file = "bcrypt-4.0.0-cp36-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:2d0dd19aad87e4ab882ef1d12df505f4c52b28b69666ce83c528f42c07379227"},
+    {file = "bcrypt-4.0.0-cp36-abi3-musllinux_1_1_aarch64.whl", hash = "sha256:bf413f2a9b0a2950fc750998899013f2e718d20fa4a58b85ca50b6df5ed1bbf9"},
+    {file = "bcrypt-4.0.0-cp36-abi3-musllinux_1_1_x86_64.whl", hash = "sha256:ede0f506554571c8eda80db22b83c139303ec6b595b8f60c4c8157bdd0bdee36"},
+    {file = "bcrypt-4.0.0-cp36-abi3-win32.whl", hash = "sha256:dc6ec3dc19b1c193b2f7cf279d3e32e7caf447532fbcb7af0906fe4398900c33"},
+    {file = "bcrypt-4.0.0-cp36-abi3-win_amd64.whl", hash = "sha256:0b0f0c7141622a31e9734b7f649451147c04ebb5122327ac0bd23744df84be90"},
+    {file = "bcrypt-4.0.0.tar.gz", hash = "sha256:c59c170fc9225faad04dde1ba61d85b413946e8ce2e5f5f5ff30dfd67283f319"},
 ]
 boto3 = [
-    {file = "boto3-1.24.57-py3-none-any.whl", hash = "sha256:74a50c718594a38fa846ce6951ea4704a5836194e2d4055e959baef39299d283"},
-    {file = "boto3-1.24.57.tar.gz", hash = "sha256:1be1aa320ef33d6e10e82adea3caeb0d2c185284457d1e2406339b44f45d7565"},
+    {file = "boto3-1.24.60-py3-none-any.whl", hash = "sha256:de7d5d66292c4f8e0000755117cec047adf1f0c78e192f7061ac1c54a2389968"},
+    {file = "boto3-1.24.60.tar.gz", hash = "sha256:9d2dab8abe90d4afaced79a10476642dc7b3755a2bdc1f871927f8d21af25777"},
 ]
 botocore = [
-    {file = "botocore-1.27.57-py3-none-any.whl", hash = "sha256:e55510321dba95065a071909177ab6d4e1621b41f090cefe54252af9b0766855"},
-    {file = "botocore-1.27.57.tar.gz", hash = "sha256:f3dd75a789ac1a3e3f06fe0725ee138522c106c4e6abc917a4915617c4a32662"},
+    {file = "botocore-1.27.60-py3-none-any.whl", hash = "sha256:5063d504698f379289249c5c27d9395ec72f445f0ac2ec4e0ed00135e76e5cac"},
+    {file = "botocore-1.27.60.tar.gz", hash = "sha256:5f9ddf144c7fe025a877dd31c9225563172769e9597013f50a226248f05ff6a8"},
 ]
 cachetools = [
     {file = "cachetools-3.1.1-py2.py3-none-any.whl", hash = "sha256:428266a1c0d36dc5aca63a2d7c5942e88c2c898d72139fca0e97fdd2380517ae"},
@@ -2177,8 +2175,8 @@ urllib3 = [
     {file = "urllib3-1.26.12.tar.gz", hash = "sha256:3fa96cf423e6987997fc326ae8df396db2a8b7c667747d47ddd8ecba91f4a74e"},
 ]
 websocket-client = [
-    {file = "websocket-client-1.3.3.tar.gz", hash = "sha256:d58c5f284d6a9bf8379dab423259fe8f85b70d5fa5d2916d5791a84594b122b1"},
-    {file = "websocket_client-1.3.3-py3-none-any.whl", hash = "sha256:5d55652dc1d0b3c734f044337d929aaf83f4f9138816ec680c1aefefb4dc4877"},
+    {file = "websocket-client-1.4.0.tar.gz", hash = "sha256:79d730c9776f4f112f33b10b78c8d209f23b5806d9a783e296b3813fc5add2f1"},
+    {file = "websocket_client-1.4.0-py3-none-any.whl", hash = "sha256:33ad3cf0aef4270b95d10a5a66b670a66be1f5ccf10ce390b3644f9eddfdca9d"},
 ]
 wrapt = [
     {file = "wrapt-1.14.1-cp27-cp27m-macosx_10_9_x86_64.whl", hash = "sha256:1b376b3f4896e7930f1f772ac4b064ac12598d1c38d04907e696cc4d794b43d3"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,7 +17,7 @@ jinja2 = ">=3.1.0"
 ansible-runner = "^2.2.1"
 ansible = "^6.1.0"
 importlib_resources = ">=5.4.0"
-exasol_script_languages_release = { git = "https://github.com/exasol/script-languages-release.git", branch = "develop"}
+exasol_script_languages_release = { git = "https://github.com/exasol/script-languages-release.git", tag = "5.0.0"}
 rich = "^12.5.1"
 pandas = "^1.4.0"
 

--- a/setup.py
+++ b/setup.py
@@ -38,7 +38,7 @@ install_requires = \
  'boto3>=1.22.0,<2.0.0',
  'click>=8.1.3,<9.0.0',
  'exasol_script_languages_release @ '
- 'git+https://github.com/exasol/script-languages-release.git@develop',
+ 'git+https://github.com/exasol/script-languages-release.git@5.0.0',
  'importlib_resources>=5.4.0',
  'jinja2>=3.1.0',
  'pandas>=1.4.0,<2.0.0',

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -70,7 +70,8 @@ def local_stack():
 def test_config():
     test_config = {
         "time_to_wait_for_polling": 0.01,
-        "source_ami_filters": default_config_object.source_ami_filters
+        "source_ami_filters": default_config_object.source_ami_filters,
+        "slc_version": default_config_object.slc_version
     }
     return ConfigObject(**test_config)
 

--- a/test/conftest.py
+++ b/test/conftest.py
@@ -66,7 +66,7 @@ def local_stack():
     subprocess.run(shlex.split(command), env=env_variables)
 
 
-@pytest.fixture(autouse=True)
+@pytest.fixture(scope="session")
 def test_config():
     test_config = {
         "time_to_wait_for_polling": 0.01,

--- a/test/test_ansible.py
+++ b/test/test_ansible.py
@@ -29,37 +29,37 @@ class AnsibleTestAccess:
             self.delegate(private_data_dir, run_ctx)
 
 
-def test_run_ansible_default_values():
+def test_run_ansible_default_values(test_config):
     """
     Test which executes run_install_dependencies with default values (default playbook and default ansible variables)
     """
     ansible_access = AnsibleTestAccess()
-    run_install_dependencies(ansible_access)
+    run_install_dependencies(ansible_access, test_config)
     expected_ansible_run_context = AnsibleRunContext(playbook="slc_setup.yml", extra_vars={"slc_version": "master"})
     assert ansible_access.call_arguments.private_data_dir.startswith("/tmp")
     assert ansible_access.call_arguments.run_ctx == expected_ansible_run_context
 
 
-def test_run_ansible_custom_playbook():
+def test_run_ansible_custom_playbook(test_config):
     """
     Test which executes run_install_dependencies with default ansible variable, but a custom playbook
     """
     ansible_access = AnsibleTestAccess()
     ansible_run_context = AnsibleRunContext(playbook="my_playbook.yml", extra_vars=dict())
-    run_install_dependencies(ansible_access, host_infos=tuple(), ansible_run_context=ansible_run_context)
+    run_install_dependencies(ansible_access, test_config, host_infos=tuple(), ansible_run_context=ansible_run_context)
 
     expected_ansible_run_context = AnsibleRunContext(playbook="my_playbook.yml", extra_vars={"slc_version": "master"})
     assert ansible_access.call_arguments.private_data_dir.startswith("/tmp")
     assert ansible_access.call_arguments.run_ctx == expected_ansible_run_context
 
 
-def test_run_ansible_custom_variables():
+def test_run_ansible_custom_variables(test_config):
     """
     Test which executes run_install_dependencies with custam playbook and custom ansible variables
     """
     ansible_access = AnsibleTestAccess()
     ansible_run_context = AnsibleRunContext(playbook="my_playbook.yml", extra_vars={"my_var": True})
-    run_install_dependencies(ansible_access, host_infos=tuple(), ansible_run_context=ansible_run_context)
+    run_install_dependencies(ansible_access, test_config, host_infos=tuple(), ansible_run_context=ansible_run_context)
 
     expected_ansible_run_context = AnsibleRunContext(playbook="my_playbook.yml",
                                                      extra_vars={"slc_version": "master", "my_var": True})
@@ -67,7 +67,7 @@ def test_run_ansible_custom_variables():
     assert ansible_access.call_arguments.run_ctx == expected_ansible_run_context
 
 
-def test_run_ansible_check_inventory_empty_host():
+def test_run_ansible_check_inventory_empty_host(test_config):
     empty_inventory = "[ec2]\n\n"
 
     def check_inventory(work_dir: str, ansible_run_context: AnsibleRunContext):
@@ -75,10 +75,10 @@ def test_run_ansible_check_inventory_empty_host():
             inventory_content = f.read()
         assert inventory_content == empty_inventory
 
-    run_install_dependencies(AnsibleTestAccess(check_inventory))
+    run_install_dependencies(AnsibleTestAccess(check_inventory), test_config)
 
 
-def test_run_ansible_check_inventory_custom_host():
+def test_run_ansible_check_inventory_custom_host(test_config):
     custom_inventory = "[ec2]\n\nmy_host ansible_ssh_private_key_file=my_key\n\n"
 
     def check_inventory(work_dir: str, ansible_run_context: AnsibleRunContext):
@@ -86,10 +86,11 @@ def test_run_ansible_check_inventory_custom_host():
             inventory_content = f.read()
         assert inventory_content == custom_inventory
 
-    run_install_dependencies(AnsibleTestAccess(check_inventory), host_infos=(HostInfo("my_host", "my_key"),))
+    run_install_dependencies(AnsibleTestAccess(check_inventory), test_config,
+                             host_infos=(HostInfo("my_host", "my_key"),))
 
 
-def test_run_ansible_check_default_repository():
+def test_run_ansible_check_default_repository(test_config):
     """
     Test that default repository is being copied correctly.
     For simplicity, we check only if:
@@ -102,10 +103,10 @@ def test_run_ansible_check_default_repository():
         p = pathlib.Path(work_dir) / "roles" / "script_languages" / "tasks" / "main.yml"
         assert p.exists()
 
-    run_install_dependencies(AnsibleTestAccess(check_playbook))
+    run_install_dependencies(AnsibleTestAccess(check_playbook), test_config)
 
 
-def test_run_ansible_check_multiple_repositories():
+def test_run_ansible_check_multiple_repositories(test_config):
     """
     Test that multiple repositories are being copied correctly.
     For simplicity, we check only if the playbook of the repositories exists on target.
@@ -117,16 +118,16 @@ def test_run_ansible_check_multiple_repositories():
         assert p.exists()
 
     test_repositories = default_repositories + (AnsibleResourceRepository(test.ansible),)
-    run_install_dependencies(AnsibleTestAccess(check_playbooks), host_infos=tuple(),
+    run_install_dependencies(AnsibleTestAccess(check_playbooks), test_config, host_infos=tuple(),
                              ansible_run_context=default_ansible_run_context, ansible_repositories=test_repositories)
 
 
-def test_run_ansible_check_multiple_repositories_with_same_content_causes_exception():
+def test_run_ansible_check_multiple_repositories_with_same_content_causes_exception(test_config):
     """
     Test that multiple repositories containing same files raises an runtime exception.
     """
     test_repositories = default_repositories + (AnsibleResourceRepository(test.ansible_conflict),)
     with pytest.raises(RuntimeError):
-        run_install_dependencies(AnsibleTestAccess(), host_infos=tuple(),
+        run_install_dependencies(AnsibleTestAccess(), test_config, host_infos=tuple(),
                                  ansible_run_context=default_ansible_run_context,
                                  ansible_repositories=test_repositories)

--- a/test/test_ansible.py
+++ b/test/test_ansible.py
@@ -35,7 +35,8 @@ def test_run_ansible_default_values(test_config):
     """
     ansible_access = AnsibleTestAccess()
     run_install_dependencies(ansible_access, test_config)
-    expected_ansible_run_context = AnsibleRunContext(playbook="slc_setup.yml", extra_vars={"slc_version": "master"})
+    expected_ansible_run_context = AnsibleRunContext(playbook="slc_setup.yml",
+                                                     extra_vars={"slc_version": test_config.slc_version})
     assert ansible_access.call_arguments.private_data_dir.startswith("/tmp")
     assert ansible_access.call_arguments.run_ctx == expected_ansible_run_context
 
@@ -48,7 +49,8 @@ def test_run_ansible_custom_playbook(test_config):
     ansible_run_context = AnsibleRunContext(playbook="my_playbook.yml", extra_vars=dict())
     run_install_dependencies(ansible_access, test_config, host_infos=tuple(), ansible_run_context=ansible_run_context)
 
-    expected_ansible_run_context = AnsibleRunContext(playbook="my_playbook.yml", extra_vars={"slc_version": "master"})
+    expected_ansible_run_context = AnsibleRunContext(playbook="my_playbook.yml",
+                                                     extra_vars={"slc_version": test_config.slc_version})
     assert ansible_access.call_arguments.private_data_dir.startswith("/tmp")
     assert ansible_access.call_arguments.run_ctx == expected_ansible_run_context
 
@@ -62,7 +64,8 @@ def test_run_ansible_custom_variables(test_config):
     run_install_dependencies(ansible_access, test_config, host_infos=tuple(), ansible_run_context=ansible_run_context)
 
     expected_ansible_run_context = AnsibleRunContext(playbook="my_playbook.yml",
-                                                     extra_vars={"slc_version": "master", "my_var": True})
+                                                     extra_vars={"slc_version": test_config.slc_version,
+                                                                 "my_var": True})
     assert ansible_access.call_arguments.private_data_dir.startswith("/tmp")
     assert ansible_access.call_arguments.run_ctx == expected_ansible_run_context
 

--- a/test/test_ci.py
+++ b/test/test_ci.py
@@ -2,7 +2,6 @@ import os
 import time
 
 from datetime import datetime
-from pathlib import Path
 
 import botocore
 import paramiko
@@ -13,11 +12,10 @@ import requests
 
 from invoke import Responder
 
-from exasol_script_languages_developer_sandbox.cli.options.id_options import DEFAULT_ID
 from exasol_script_languages_developer_sandbox.lib.ansible.ansible_access import AnsibleAccess
 from exasol_script_languages_developer_sandbox.lib.asset_id import AssetId
 from exasol_script_languages_developer_sandbox.lib.aws_access.aws_access import AwsAccess
-from exasol_script_languages_developer_sandbox.lib.config import default_config_object
+from exasol_script_languages_developer_sandbox.lib.config import default_config_object, SLC_VERSION
 from exasol_script_languages_developer_sandbox.lib.run_create_vm import run_create_vm
 from exasol_script_languages_developer_sandbox.lib.setup_ec2.run_setup_ec2 import run_lifecycle_for_ec2, \
     EC2StackLifecycleContextManager
@@ -75,7 +73,7 @@ def new_ec2_from_ami():
     assert default_password != new_password
     aws_access = AwsCiAccess(aws_profile=None)
     asset_id = AssetId("ci-test-{suffix}-{now}".format(now=datetime.now().strftime("%Y-%m-%d-%H-%M-%S"),
-                                                       suffix=DEFAULT_ID),
+                                                       suffix=SLC_VERSION),
                        stack_prefix="stack",
                        ami_prefix="ami")
     run_create_vm(aws_access, None, None,

--- a/test/test_install_dependencies.py
+++ b/test/test_install_dependencies.py
@@ -20,7 +20,7 @@ TEST_CONTAINER_IMAGE_TAG = "script_languages_developer_sandbox_test_container:la
 
 
 @pytest.fixture(scope="session")
-def docker_test_container():
+def docker_test_container(test_config):
     with tempfile.TemporaryDirectory() as tmp_dir:
         docker_env = docker.from_env()
         p = Path(__file__).parent / "test_container"
@@ -37,7 +37,8 @@ def docker_test_container():
             AnsibleRunContext(playbook="slc_setup_test.yml",
                               extra_vars={"test_docker_container": test_container.name,
                                           "slc_dest_folder": f"{tmp_dir}/script-languages-release"})
-        run_install_dependencies(AnsibleAccess(), host_infos=tuple(), ansible_run_context=ansible_run_context,
+        run_install_dependencies(AnsibleAccess(), configuration=test_config,
+                                 host_infos=tuple(), ansible_run_context=ansible_run_context,
                                  ansible_repositories=repos)
         yield test_container, tmp_dir
         # Note: script-languages-release will be cloned by ansible within the docker container.


### PR DESCRIPTION
fixes #12 

1. Update dependency to poetry toml to use latest script-languages-release tag
2. Ansible scripts now use the dependant slc version for installation of the script-languages-release repository
3. Moved the slc version definition into the config object: With that the slc version gets injected into the code and could be changed for the tests.